### PR TITLE
sulu:document:initialize command

### DIFF
--- a/cookbook/create-new-webspace.rst
+++ b/cookbook/create-new-webspace.rst
@@ -12,10 +12,13 @@ similar to the `sulu_io.xml.dist` file in this folder.
 
 To activate the webspace within sulu with a `prod` or `stage` environment
 you have to clear the cache with the command:
-`app/console clear:cache -e <environment>`
 
-To initiate the database for the new webspace run the command
-`app/console sulu:phpcr:init && app/console sulu:webspaces:init`.
+    $ app/console cache:clear -e <environment>
+
+Afterwards you will need to initialize the new webspace, to do so run the
+following command:
+
+    $ app/console sulu:document:initialize
 
 To allow users to see the new webspace you also have to set the permissions in
 the roles for the new webspace.


### PR DESCRIPTION
Modified documentation to remove references to `sulu:webspaces:init` and `sulu:phpcr:init`.