### PR TITLE
Fixed navigation twig extensions

### DIFF
--- a/reference/twig-extensions/functions/sulu_navigation_flat.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_flat.rst
@@ -1,10 +1,11 @@
-``sulu_navigation_root_flat``
-=============================
+``sulu_navigation_flat``
+========================
 
-Returns navigation Page from root in a flat list data-structure.
+Returns navigation from the given page in a flat list data-structure.
 
 **Arguments**:
 
+- **uuid**: *string* The uuid for which the navigation should be loaded
 - **context**: *string* - optional: context to filter navigation
 - **depth**: *integer* - optional: depth to load (1 - childs, 2 - childs and child of childs, ...)
 - **loadExcerpt**: *boolean* - optional: load data from excerpt tab

--- a/reference/twig-extensions/functions/sulu_navigation_root_flat.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_root_flat.rst
@@ -1,7 +1,7 @@
 ``sulu_navigation_root_flat``
 =============================
 
-Returns navigation Page from root in a flat list data-structure.
+Returns navigation from root in a flat list data-structure.
 
 **Arguments**:
 

--- a/reference/twig-extensions/functions/sulu_navigation_root_tree.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_root_tree.rst
@@ -1,7 +1,7 @@
 ``sulu_navigation_root_tree``
 =============================
 
-Returns navigation Page from root in a tree data-structure.
+Returns navigation from root in a tree data-structure.
 
 **Arguments**:
 

--- a/reference/twig-extensions/functions/sulu_navigation_tree.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_tree.rst
@@ -1,10 +1,11 @@
 ``sulu_navigation_tree``
 ========================
 
-Returns navigation Page from root in a tree data-structure.
+Returns navigation from the given page in a tree data-structure.
 
 **Arguments**:
 
+- **uuid**: *string* The uuid for which the navigation should be loaded
 - **context**: *string* - optional: context to filter navigation
 - **depth**: *integer* - optional: depth to load (1 - childs, 2 - childs and child of childs, ...)
 - **loadExcerpt**: *boolean* - optional: load data from excerpt tab


### PR DESCRIPTION
One of the title of the navigation twig functions was wrong, and the descriptions for the non-root methods were not correct.