### PR TITLE
Fix github urls after rename of organization

### DIFF
--- a/book/creating-a-basic-website/creating-a-twig-template.rst
+++ b/book/creating-a-basic-website/creating-a-twig-template.rst
@@ -171,8 +171,8 @@ Just have a look at our `default theme`_, that ships with our standard
 installation as long with our `default page templates`_ over at github.
 
 
-.. _default theme: https://github.com/sulu-io/sulu-standard/tree/master/src/Client/Bundle/WebsiteBundle/Resources/themes/default
-.. _default page templates: https://github.com/sulu-io/sulu-standard/tree/master/app/Resources/pages
-.. _example file: https://github.com/sulu-io/sulu-standard/blob/master/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/example.html.twig
-.. _image_formats.xml: https://github.com/sulu-io/sulu-standard/blob/master/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
-.. _Sulu Homepage: http://www.sulu.io
+.. _default theme: https://github.com/sulu/sulu-standard/tree/master/src/Client/Bundle/WebsiteBundle/Resources/themes/default
+.. _default page templates: https://github.com/sulu/sulu-standard/tree/master/app/Resources/pages
+.. _example file: https://github.com/sulu/sulu-standard/blob/master/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/example.html.twig
+.. _image_formats.xml: https://github.com/sulu/sulu-standard/blob/master/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
+.. _Sulu Homepage: http://sulu.io

--- a/book/getting-started/installation.rst
+++ b/book/getting-started/installation.rst
@@ -8,12 +8,12 @@ Get the code
 ------------
 
 First of all you have to clone the `sulu-standard repository on GitHub
-<https://github.com/sulu-io/sulu-standard>`_ and change into the cloned
+<https://github.com/sulu/sulu-standard>`_ and change into the cloned
 directory.
 
 .. code-block:: bash
 
-    $ git clone https://github.com/sulu-io/sulu-standard.git
+    $ git clone https://github.com/sulu/sulu-standard.git
 
 After the clone has finished, you can change to the cloned directory, and
 checkout the latest version of Sulu:

--- a/cookbook/caching-with-varnish.rst
+++ b/cookbook/caching-with-varnish.rst
@@ -313,4 +313,4 @@ The following is a full configuration example:
 
 .. _caching proxy: https://en.wikipedia.org/wiki/Proxy_server
 .. _HttpCache: http://symfony.com/doc/current/book/http_cache.html
-.. _standard edition: http://github.com/sulu-io/sulu-standard
+.. _standard edition: http://github.com/sulu/sulu-standard

--- a/cookbook/running-sulu-on-heroku.rst
+++ b/cookbook/running-sulu-on-heroku.rst
@@ -29,5 +29,5 @@ For more details about working with Heroku you should check out the `Heroku Dev
 Center`_.
 
 .. _Heroku: http://www.heroku.com
-.. _Sulu cloud edition: https://github.com/sulu-io/sulu-cloud
+.. _Sulu cloud edition: https://github.com/sulu/sulu-cloud
 .. _Heroku Dev Center: https://devcenter.heroku.com/

--- a/cookbook/websocket.rst
+++ b/cookbook/websocket.rst
@@ -11,7 +11,7 @@ Configuration
 -------------
 
 If you use the config layout of `sulu-standard
-<https://github.com/sulu-io/sulu-standard>`_ you only have to set following
+<https://github.com/sulu/sulu-standard>`_ you only have to set following
 parameters in the ``parameters.yml`` file.
 
 .. list-table::

--- a/developer/contributing/pull-requests.rst
+++ b/developer/contributing/pull-requests.rst
@@ -66,7 +66,7 @@ An example submission could now look as follows:
     | Fixed tickets      | fixes #1243, fixes #1443
     | Related issues/PRs | -
     | License            | MIT
-    | Documentation PR   | sulu-io/sulu-docs#153
+    | Documentation PR   | sulu/sulu-docs#153
 
 Some answers to the questions trigger some more requirements:
 
@@ -141,5 +141,5 @@ because you want early feedback on your work, add an item to to-do list:
 
 Remove this section if not needed.
 
-.. _documentation repository: https://github.com/sulu-io/sulu-docs
-.. _Sulu organization: https://github.com/sulu-io
+.. _documentation repository: https://github.com/sulu/sulu-docs
+.. _Sulu organization: https://github.com/sulu

--- a/developer/contributing/test-your-code.rst
+++ b/developer/contributing/test-your-code.rst
@@ -96,4 +96,4 @@ to let Symfony override default parameters:
 More information in the `Symfony docs`_. For a list of available parameters take a look into the `parameter.yml`_.
 
 .. _Symfony docs: http://symfony.com/doc/current/cookbook/configuration/external_parameters.html
-.. _parameter.yml: https://github.com/sulu-io/sulu/tree/develop/src/Sulu/Bundle/TestBundle/Resources/dist/parameter.yml
+.. _parameter.yml: https://github.com/sulu/sulu/tree/develop/src/Sulu/Bundle/TestBundle/Resources/dist/parameter.yml

--- a/index.rst
+++ b/index.rst
@@ -32,7 +32,7 @@ We are also on `Github`_. Pull requests and contributions are very welcome.
 
 Have fun with Sulu.
 
-.. _Sulu: http://www.sulu.io
-.. _website: http://www.sulu.io
+.. _Sulu: http://sulu.io
+.. _website: http://sulu.io
 .. _contact us: http://sulu.io/en/contact
-.. _github: https://github.com/sulu-io/sulu-docs
+.. _github: https://github.com/sulu/sulu-docs


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Fix all github.com/sulu-io urls to github.com/sulu

#### Why?

The github organization was renamed
