### PR TITLE
Fix example navigation twig

### DIFF
--- a/book/creating-a-basic-website/creating-a-twig-template.rst
+++ b/book/creating-a-basic-website/creating-a-twig-template.rst
@@ -121,7 +121,7 @@ context.
     :linenos:
 
     <ul>
-        {% for item in sulu_navigation_root_tree('main') %}
+        {% for item in sulu_navigation_root_tree('main', 2) %}
         <li>
             <a href="{{ sulu_content_path(item.url) }}" 
                 title="{{ item.title }}">{{ item.title }}</a>


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

The navigation twig extension need a depth when you want a subnavigation.

#### Why?

Currently their is no depth given.

