### PR TITLE
Restructured theme docs

### DIFF
--- a/book/creating-a-basic-website/adding-a-template.rst
+++ b/book/creating-a-basic-website/adding-a-template.rst
@@ -135,9 +135,8 @@ includes the `view`, which is the reference to the twig template, and the
 template. For standard templates you don't have to define your own controllers,
 because you can use the `index`-action of the `DefaultController` in the
 `SuluwebsiteBundle`. Both the template and controller have to be referenced
-as described in the `Template Naming and Locations`_ (with the addition of the
-`LiipThemeBundle`_) and `Controller Naming Pattern`_ in the Symfony
-documentation.
+as described in the `Template Naming and Locations`_ and
+`Controller Naming Pattern`_ in the Symfony documentation.
 
 The `meta`-tag consists of another `title`-tag for each available language,
 which will be displayed in the template selection of the Sulu administration
@@ -169,5 +168,4 @@ corresponding theme.
 
 .. _`Controller Naming Pattern`: http://symfony.com/doc/current/book/routing.html#controller-string-syntax
 .. _`Template Naming and Locations`: http://symfony.com/doc/current/book/templating.html#template-naming-locations
-.. _`LiipThemeBundle`: https://github.com/liip/LiipThemeBundle#theme-cascading-order
 

--- a/book/creating-a-basic-website/adding-a-theme.rst
+++ b/book/creating-a-basic-website/adding-a-theme.rst
@@ -18,6 +18,60 @@ decide which theme to use, by a simple key in the webspace configuration file
 already described in :doc:`setup-a-webspace`. This means that it is also very
 easy to switch between different themes.
 
+This feature is not shipped with a minimal sulu-installation. But can be easily
+integrated.
+
+Installation
+------------
+
+First add the dependency to the `SuluThemeBundle`_ in your `composer.json` file.
+
+.. code-block:: xml
+
+    composer require sulu/theme-bundle
+
+To enable it add the following lines into the `app/AbstractKernel.php` and
+`app/config/config.yml`.
+
+.. code-block:: xml
+
+    abstract class AbstractKernel extends SuluKernel
+    {
+        /**
+         * {@inheritdoc}
+         */
+        public function registerBundles()
+        {
+            $bundles = [
+                ...
+
+                new Sulu\Bundle\ThemeBundle\SuluThemeBundle(),
+                new Liip\ThemeBundle\LiipThemeBundle(),
+
+                ...
+            ];
+
+            ...
+
+            return $bundles;
+        }
+    }
+
+.. code-block:: yaml
+
+    # LIIP Theme Configuration
+    liip_theme:
+        themes: ["default"]
+        active_theme: "default"
+        load_controllers: false
+        assetic_integration: true
+
+This will configure a default theme which can be enabled in the
+`app/Resources/webspaces/<webspace>.xml` file by adding:
+
+.. code-block:: xml
+
+    <theme>default</theme>
 
 Create a theme
 --------------
@@ -48,91 +102,6 @@ following list:
     liip_theme:
         themes: ["default", "your-new-shiny-theme"]
 
-
-Configure image formats
------------------------
-
-If you are using images, you probably also care about the available image
-formats. Sulu also supports you with that issue. You can define different image
-formats, which Sulu will then create for every uploaded image. This generation
-is based on your configuration. You can define the formats in the file 
-`Resources/themes/<theme>/config/image-formats.xml`. Take a look at the
-following file for an example:
-
-.. code-block:: xml
-
-    <?xml version="1.0" encoding="UTF-8"?>
-    <formats xmlns="http://schemas.sulu.io/media/formats"
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.0.xsd">
-        <format>
-            <name>640x480</name>
-            <commands>
-                <command>
-                    <action>resize</action>
-                    <parameters>
-                        <parameter name="x">640</parameter>
-                        <parameter name="y">480</parameter>
-                    </parameters>
-                </command>
-            </commands>
-            <!-- optional compression for this format -->
-            <options>
-                <option name="jpeg_quality">80</option>
-                <option name="png_compression_level">6</option>
-            </options>
-        </format>
-    </formats>
-
-With the format tag you are creating a new image format. You have to name this
-format, and create a list of commands to execute on it. The example will resize
-the uploaded image to the size defined with the two parameters.
-
-The next table shows the standard commands available with its parameters.
-
-+---------+------------------------------------+
-| Command | Parameters                         |
-+=========+====================================+
-| Resize  | x: the new width                   |
-|         |                                    |
-|         | y: the new height                  |
-+---------+------------------------------------+
-| Scale   | x: the new width                   |
-|         |                                    |
-|         | y: the new height                  |
-|         |                                    |
-|         | forceRatio: true/false             |
-|         |                                    |
-|         | mode: 'inset' or 'outbound'        |
-+---------+------------------------------------+
-| Crop    | x: x-coordinate of the startpoint  |
-|         |                                    |
-|         | y: y-coordinate of the startpoint  |
-|         |                                    |
-|         | w: the with of the new image       |
-|         |                                    |
-|         | h: the height of the new image     |
-+---------+------------------------------------+
-
-Global Image Compression
-------------------------
-Images will not get compressed by default, if you upload them. You can set the
-compression for images globally in the sulu.yml or seperat for each image
-format like in the example above.
-
-To set the compression for all images you have to add following lines to your
-``config.yml``:
-
-.. code-block:: yaml
-
-    sulu_media:
-        format_manager:
-            default_imagine_options:
-                jpeg_quality: 80
-                png_compression_level: 6
-
-With the theme we got the container for our Twig-templates. That's what we'll
-do next: Writing awesome Twig files.
-
 .. _LiipThemeBundle: https://github.com/liip/LiipThemeBundle
-
+.. _`Theme cascading order`: https://github.com/liip/LiipThemeBundle#theme-cascading-order
+.. _SuluThemeBundle: https://github.com/sulu/SuluThemeBundle

--- a/book/creating-a-basic-website/configuring-image-formats.rst
+++ b/book/creating-a-basic-website/configuring-image-formats.rst
@@ -1,0 +1,86 @@
+Configure image formats
+=======================
+
+If you are using images, you probably also care about the available image
+formats. Sulu also supports you with that issue. You can define different image
+formats, which Sulu will create for every uploaded image. This generation
+is based on your configuration. You can define the formats in the file
+`Resources/themes/<theme>/config/image-formats.xml` or
+`%kernel.root_dir%/config/image-formats.xml` (if theme are not enabled).
+Take a look at the following file for an example:
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <formats xmlns="http://schemas.sulu.io/media/formats"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.0.xsd">
+        <format>
+            <name>640x480</name>
+            <commands>
+                <command>
+                    <action>resize</action>
+                    <parameters>
+                        <parameter name="x">640</parameter>
+                        <parameter name="y">480</parameter>
+                    </parameters>
+                </command>
+            </commands>
+            <!-- optional compression for this format -->
+            <options>
+                <option name="jpeg_quality">80</option>
+                <option name="png_compression_level">6</option>
+            </options>
+        </format>
+    </formats>
+
+With the format tag you are creating a new image format. You have to name this
+format, and create a list of commands to execute on it. The example will resize
+the uploaded image to the size defined with the two parameters.
+
+The next table shows the standard commands available with its parameters.
+
++---------+------------------------------------+
+| Command | Parameters                         |
++=========+====================================+
+| Resize  | x: the new width                   |
+|         |                                    |
+|         | y: the new height                  |
++---------+------------------------------------+
+| Scale   | x: the new width                   |
+|         |                                    |
+|         | y: the new height                  |
+|         |                                    |
+|         | forceRatio: true/false             |
+|         |                                    |
+|         | mode: 'inset' or 'outbound'        |
++---------+------------------------------------+
+| Crop    | x: x-coordinate of the startpoint  |
+|         |                                    |
+|         | y: y-coordinate of the startpoint  |
+|         |                                    |
+|         | w: the with of the new image       |
+|         |                                    |
+|         | h: the height of the new image     |
++---------+------------------------------------+
+
+Global Image Compression
+------------------------
+
+Images will not get compressed by default, if you upload them. You can set the
+compression for images globally in the sulu.yml or seperat for each image
+format like in the example above.
+
+To set the compression for all images you have to add following lines to your
+``config.yml``:
+
+.. code-block:: yaml
+
+    sulu_media:
+        format_manager:
+            default_imagine_options:
+                jpeg_quality: 80
+                png_compression_level: 6
+
+With the theme we got the container for our Twig-templates. That's what we'll
+do next: Writing awesome Twig files.

--- a/book/creating-a-basic-website/creating-a-twig-template.rst
+++ b/book/creating-a-basic-website/creating-a-twig-template.rst
@@ -40,7 +40,12 @@ In :doc:`adding-a-template` we learned how to define a template.
     </template>
 
 
-In the page template the view could be set.
+In the page template the view could be set. Internally Sulu appends the format
+of the request to find the correct template to render the response. As an
+example sulu uses for a html request the template
+`ClientWebsiteBundle:templates:default.html.twig` or
+`ClientWebsiteBundle:templates:default.xml.twig` for a xml request. With this
+feature you are able to define different output format for a single page.
 
 
 Rendering the Content

--- a/book/creating-a-basic-website/index.rst
+++ b/book/creating-a-basic-website/index.rst
@@ -13,10 +13,11 @@ into smart content and localization.
     about-the-sulu-content-architecture
     setup-a-webspace
     adding-a-template
-    adding-a-theme
+    configuring-image-formats
     creating-a-twig-template
     using-smart-content
     adding-localizations
+    adding-a-theme
 
 At first we'll have another look at the content architecture on a technical level
 and afterwards we will create stuff.

--- a/book/creating-a-basic-website/setup-a-webspace.rst
+++ b/book/creating-a-basic-website/setup-a-webspace.rst
@@ -22,7 +22,7 @@ be explained in the following paragraphs.
     <?xml version="1.0" encoding="utf-8"?>
     <webspace xmlns="http://schemas.sulu.io/webspace/webspace"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.0.xsd">
+              xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
 
         <name>Example</name>
         <key>example</key>
@@ -31,13 +31,10 @@ be explained in the following paragraphs.
             <localization language="en"/>
         </localizations>
 
-        <theme>
-            <key>default</key>
-            <default-templates>
-                <default-template type="page">example</default-template>
-                <default-template type="homepage">default</default-template>
-            </default-templates>    
-        </theme>
+        <default-templates>
+            <default-template type="page">example</default-template>
+            <default-template type="homepage">default</default-template>
+        </default-templates>
 
         <navigation>
             <contexts>
@@ -101,12 +98,14 @@ the available localizations:
 For a more complete explanation you should have a look at
 :doc:`adding-localizations`.
 
-Themes
-------
+Themes (optional)
+-----------------
 
 The `theme` is described by a key. This key leads to a certain theme,
 implemented by a developer in the system. Read more about themes in the section
-:doc:`adding-a-theme`.
+:doc:`adding-a-theme`. This feature is default deactivated and therefore in the
+example not used. If you have multiple webspaces which should look different,
+you can use this feature to easily do this.
 
 Navigation
 ----------


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | none
| License | MIT

#### What's in this PR?

This bundle changes the documentation to fit the removed liip-theme bundle and adds the documentation to install the sulu/theme-bundle.

#### Why?

The theming for sulu was extracted into an own bundle.

