### PR TITLE
Replaced "fallback_enabled" with "default_enabled"

### DIFF
--- a/cookbook/default-snippets.rst
+++ b/cookbook/default-snippets.rst
@@ -9,7 +9,7 @@ the form and can have a big impact on the page.
 .. note::
 
     This feature is disabled by default and can be activated by setting the
-    config value `sulu_snippet.types.snippet.fallback_enabled` to true.
+    config value `sulu_snippet.types.snippet.default_enabled` to true.
 
 Configuration
 -------------


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Replaced "fallback_enabled" with "default_enabled"

#### Why?

Fixed default-snippets documentation.