### PR TITLE
Replaced "fallback_enabled" with "default_enabled"

### DIFF
--- a/reference/content-types/snippet.rst
+++ b/reference/content-types/snippet.rst
@@ -30,7 +30,7 @@ Parameters
 .. note::
 
     The fallback mechanism has to be enabled in the config:
-    `sulu_snippet.types.snippet.fallback_enabled`.
+    `sulu_snippet.types.snippet.default_enabled`.
 
 Example
 -------


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Replaced "fallback_enabled" with "default_enabled"

#### Why?

Fixed default-snippets documentation
