### PR TITLE
Twig template example using wrong twig function

### DIFF
--- a/reference/content-types/smart_content.rst
+++ b/reference/content-types/smart_content.rst
@@ -276,7 +276,7 @@ Twig template
     {% for page in content.pages %}
         <div class="col-lg-{{ view.pages.presentAs == 'two' ? '6' : '12' }}">
             <h2>
-                <a href="{{ content_path(page.url) }}">{{ page.title }}</a>
+                <a href="{{ sulu_content_path(page.url) }}">{{ page.title }}</a>
             </h2>
             <p>
                 <i>{{ page.excerptTitle }}</i> | <i>{{ page.excerptTags|join(', ') }}</i>


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Fix example twig template of the smart content

#### Why?

There is content_path used in the example, but I thing that sulu_content_path should be used.