### PR TITLE
remove port from url configuration

### DIFF
--- a/book/creating-a-basic-website/setup-a-webspace.rst
+++ b/book/creating-a-basic-website/setup-a-webspace.rst
@@ -171,12 +171,6 @@ environments, which have to match the environments defined in Symfony. Usually
 `dev`, `stage` and `prod` are available. Each environment can define its own
 set of URLs.
 
-.. note::
-    
-    Please consider that you have to omit the port in the configuration. The
-    system will work with any port, so you don't have to name it in the
-    configuration.
-
 The URLs also have to include the localization somehow. You have two
 possibilities to do so:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | none
| License | MIT

#### What's in this PR?

This PR removes the port from the URL configuration part, because we are not allowed to omit them, and haven't actually been.

#### Why?

Omitting the port does not work, because the system does not recognize the URL then.

