### PR TITLE
 #306 Updated DataFixture example - publish page/document

### DIFF
--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -55,6 +55,7 @@ Shown below is the simple data fixtures:
             $documentManager->persist($document, 'en', array(
                 'parent_path' => '/cmf/sulu_io/contents',
             ));
+            $documentManager->publish($document,'de');
             $documentManager->flush();
         }
     }

--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -55,7 +55,7 @@ Shown below is the simple data fixtures:
             $documentManager->persist($document, 'en', array(
                 'parent_path' => '/cmf/sulu_io/contents',
             ));
-            $documentManager->publish($document,'de');
+            $documentManager->publish($document,'en');
             $documentManager->flush();
         }
     }


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #306 
| License | MIT

#### What's in this PR?

Just added the `$documentManager->publish($document, 'en'); call in the example code.

#### Why?

According to the discussion in #306 and the seperation of phpcr workspaces in sulu 1.3 it is required to call publish after persisting a document to actually add a published document.
