### PR TITLE
Update nginx documentation with usage of port 80

### DIFF
--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -6,7 +6,7 @@ The Nginx configuration could look something like.
 .. code-block:: nginx
 
   server {
-      listen 8081;
+      listen 80;
 
       server_name sulu.lo;
       root /var/www/sulu.lo/web;


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Use port 80 instead of port 8081 in the nginx example.

#### Why?

Port 80 is the default http port.
