### PR TITLE
Fix incorrect 'implements' keyword usage in Fixture documentation

### DIFF
--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -121,7 +121,7 @@ If you need the service container you can implement the `Symfony\Component\Depen
     use Symfony\Component\DependencyInjection\ContainerAwareInterface;
     use Symfony\Component\DependencyInjection\ContainerInterface;
 
-    class SomeFixture implements DocumentFixtureInterface implements ContainerAwareInterface
+    class SomeFixture implements DocumentFixtureInterface, ContainerAwareInterface
     {
         private $container;
 


### PR DESCRIPTION
This is the correct way to implement 2 interfaces.

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Documentation improvement/correction

#### Why?

To help users starting out with Sulu
