### PR TITLE
Add example usage of countries parameter in location content type

### DIFF
--- a/reference/content-types/location.rst
+++ b/reference/content-types/location.rst
@@ -39,4 +39,11 @@ Example
         <meta>
             <title lang="en">Location</title>
         </meta>
+        <params>
+          <param name="countries" type="collection">
+            <param name="AT" value="Austria"/>
+            <param name="FR" value="France"/>
+            <param name="GB" value="Great Britain"/>
+          </param>
+        </params>
     </property>


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

This PR adds an example of how to use the `countries` parameter in the `location` content type.
