### PR TITLE
Update fixtures documentation for publishing pages

### DIFF
--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -55,7 +55,10 @@ Shown below is the simple data fixtures:
             $documentManager->persist($document, 'en', array(
                 'parent_path' => '/cmf/sulu_io/contents',
             ));
+            
+            # Optional: If you don't want your document to be published, remove this line
             $documentManager->publish($document, 'en');
+            
             $documentManager->flush();
         }
     }

--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -55,6 +55,7 @@ Shown below is the simple data fixtures:
             $documentManager->persist($document, 'en', array(
                 'parent_path' => '/cmf/sulu_io/contents',
             ));
+            $documentManager->publish($document, 'en');
             $documentManager->flush();
         }
     }


### PR DESCRIPTION
The current documentation still requires the dev to log into the admin and publish pages despite setting the workflow to published. This addition publishes the pages.

| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Just a small update to actually publish pages added/updated by fixtures.

#### Why?

Had to dig into the code to figure out why the pages weren't actually being published when working from the documentation. Found that there was a step missing.
