### PR TITLE
Fix sulu_breadcrumb example

### DIFF
--- a/reference/twig-extensions/functions/sulu_breadcrumb.rst
+++ b/reference/twig-extensions/functions/sulu_breadcrumb.rst
@@ -5,7 +5,9 @@ Returns the breadcrumb for a given node UUID
 
 .. code-block:: jinja
 
-    {{ sulu_breadcrumb(node.uuid) }}
+    {% for item in sulu_breadcrumb(uuid) %}
+        <a  href="{{ sulu_content_path(item.url) }}">{{ item.title }}</a>
+    {% endfor %}
 
 **Arguments**:
 

--- a/reference/twig-extensions/functions/sulu_breadcrumb.rst
+++ b/reference/twig-extensions/functions/sulu_breadcrumb.rst
@@ -3,6 +3,8 @@
 
 Returns the breadcrumb for a given node UUID
 
+**Example**:
+
 .. code-block:: jinja
 
     {% for item in sulu_breadcrumb(uuid) %}
@@ -12,3 +14,7 @@ Returns the breadcrumb for a given node UUID
 **Arguments**:
 
 - **uuid**: *string* - UUID of page node for which to show the breadcrumb
+
+**Returns**:
+
+.. include:: _page_structure.inc

--- a/reference/twig-extensions/functions/sulu_breadcrumb.rst
+++ b/reference/twig-extensions/functions/sulu_breadcrumb.rst
@@ -6,7 +6,7 @@ Returns the breadcrumb for a given node UUID
 .. code-block:: jinja
 
     {% for item in sulu_breadcrumb(uuid) %}
-        <a  href="{{ sulu_content_path(item.url) }}">{{ item.title }}</a>
+        <a href="{{ sulu_content_path(item.url) }}">{{ item.title }}</a>
     {% endfor %}
 
 **Arguments**:


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes sulu/sulu#3324
| License | MIT

#### What's in this PR?

Fix the breadcrumb example.

#### Why?

The breadcrumb returns an array.
