### PR TITLE
Fix nginx config for media query string

### DIFF
--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -33,7 +33,7 @@ The Nginx configuration could look something like.
 
       # expire
       location ~* \.(?:ico|css|js|gif|jpe?g|png|svg|woff|woff2|eot|ttf)$ {
-          try_files $uri /website.php/$1;
+          try_files $uri /website.php/$1?$query_string;
           access_log off;
           expires 30d;
           add_header Pragma public;


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Add query string to media try files in nginx.

#### Why?

On nginx the query string is missing for assets so the versioning and disposition type is not working correctly.

