### PR TITLE
updated template references to match sulu-minimal

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -106,17 +106,19 @@ the Twig file that is used to render the template:
               xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
         <!-- ... -->
 
-        <view>ClientWebsiteBundle:templates:event</view>
+        <view>templates/event</view>
 
         <!-- ... -->
     </template>
 
 .. Note::
 
-    The notation ``bundle:directory:filename`` is `Symfony's naming convention`_
-    for Twig templates. Sulu automatically adds the ``.<format>.twig`` suffix
-    to this string, depending on the format requested by the client
-    (HTML, JSON, XML, ...).
+    Sulu automatically adds the ``.<format>.twig`` suffix to the view string,
+    depending on the format requested by the client (HTML, JSON, XML, ...).
+
+    Instead of the folder notation with the ``/`` you can use the
+    `Symfony's naming convention`_ without the file extension for Twig
+    templates.
 
 We'll talk more about the Twig file itself in :doc:`twig`. Let's continue with
 adding properties to our page template.

--- a/book/twig.rst
+++ b/book/twig.rst
@@ -34,7 +34,7 @@ In :doc:`templates` we learned how to define a template.
 
         <key>default</key>
 
-        <view>ClientWebsiteBundle:templates:default</view>
+        <view>templates/default</view>
         <controller>SuluWebsiteBundle:Default:index</controller>
         ...
     </template>
@@ -43,8 +43,8 @@ In :doc:`templates` we learned how to define a template.
 In the page template the view could be set. Internally Sulu appends the format
 of the request to find the correct template to render the response. As an
 example sulu uses for a html request the template
-`ClientWebsiteBundle:templates:default.html.twig` or
-`ClientWebsiteBundle:templates:default.xml.twig` for a xml request. With this
+`app/Resources/views/templates/default.html.twig` or
+`app/Resources/views/templates/default.xml.twig` for a xml request. With this
 feature you are able to define different output format for a single page.
 
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | ---
| License | MIT

#### What's in this PR?

This PR updates the template xml files to match the `app/Resources/view` directory instead of using a separate `ClientWebsiteBundle`.

#### Why?

Because that's the way we decided to take in the future.
