### PR TITLE
Add documentation for snippet areas

### DIFF
--- a/cookbook/default-snippets.rst
+++ b/cookbook/default-snippets.rst
@@ -1,26 +1,57 @@
 How to define a default-snippet?
 ================================
 
-Sulu gives the content-manager an easy way to define default snippets per type.
-These default-snippets will be automatically used if the snippet-selection is
-empty on a specific page. This default selection will will not be displayed in
+Sulu gives the content-manager an easy way to define default snippets per type or area.
+These default-snippets will be used if the snippet-selection is
+empty on a specific page. This default selection will not be displayed in
 the form and can have a big impact on the page.
+
+Defining areas
+--------------
+
+Sulu allows you to to reuse the same snippet template to use it as default
+for different snippet content types or load a snippet by its area key with
+the twig extension. The areas can be defined in the xml template of the snippets.
+
+.. code-block:: xml
+
+    <key>sidebar</key>
+
+    <meta>
+        <title lang="en">Sidebar</title>
+        <title lang="de">Sidebar</title>
+    </meta>
+
+    <areas>
+        <area key="sidebar_default">
+            <meta>
+                <title lang="en">Sidebar Standard</title>
+                <title lang="de">Sidebar Default</title>
+            </meta>
+        </area>
+
+        <area key="sidebar_overview">
+            <meta>
+                <title lang="en">Sidebar Overview</title>
+                <title lang="de">Sidebar Übersicht</title>
+            </meta>
+        </area>
+    </areas>
 
 .. note::
 
-    This feature is disabled by default and can be activated by setting the
-    config value `sulu_snippet.types.snippet.default_enabled` to true.
-    After that you need to activate the rights to access the default snippets in the user role section.
+    When no areas are defined sulu automatically define an area per snippet template.
+
 
 Configuration
 -------------
 
 The default snippets will be used if the following conditions are fulfilled.
 
-1. The feature has to be activated
-2. The snippet-selection parameter ``snippetType`` and ``default`` has to be
+1. The feature has to be activated (`sulu_snippet.types.snippet.default_enabled`) (default activated since 1.4)
+2. The snippet-selection parameter ``default`` has to be
    defined. See :doc:`../reference/content-types/snippet`.
-3. The default snippet for the configured type has to be selected in the
+3. The snippet for the configured area has to be selected in the
    webspace settings.
 
 This conditions match the default snippet will be injected into the page.
@@ -28,5 +59,5 @@ This conditions match the default snippet will be injected into the page.
 Usage without the content type
 ------------------------------
 
-To get the default snippet for a specific type the developer can use the
-twig-function :doc:`../reference/twig-extensions/functions/sulu_snippet_load_default`.
+To get the snippet for a specific area the developer can use the
+twig-function :doc:`../reference/twig-extensions/functions/sulu_snippet_load_by_area`.

--- a/reference/content-types/snippet.rst
+++ b/reference/content-types/snippet.rst
@@ -22,15 +22,15 @@ Parameters
       - string
       - The type of snippet to assign.
     * - default
-      - boolean - false
-      - If this parameter is true and enabled in config the content-type will
-        load the default snippets which can be specified by the content-manager
-        in the webspace settings.
+      - string - false
+      - If this parameter is true or a specified area and enabled in config the 
+        content-type will load the snippet which can be specified by the
+        content-manager in the webspace settings.
 
 .. note::
 
     The fallback mechanism has to be enabled in the config:
-    `sulu_snippet.types.snippet.default_enabled`.
+    `sulu_snippet.types.snippet.default_enabled`. (default activated since 1.4)
 
 Example
 -------
@@ -43,6 +43,7 @@ Example
         </meta>
         
         <params>
-            <param name="snippetType" value="animal"/>
+            <param name="snippetType" value="sidebar"/>
+            <param name="default" value="sidebar_overview"/>
         </params>
     </property>

--- a/reference/twig-extensions/functions/_snippet_structure.inc
+++ b/reference/twig-extensions/functions/_snippet_structure.inc
@@ -4,4 +4,5 @@
      - **changer**: User ID of changer
      - **created**: Date of creation
      - **creator**: User ID of creator
-     - **content**: Snippet data
+     - **content**: Snippet content data
+     - **view**: Snippet view data

--- a/reference/twig-extensions/functions/sulu_snippet_load_by_area.rst
+++ b/reference/twig-extensions/functions/sulu_snippet_load_by_area.rst
@@ -1,0 +1,19 @@
+``sulu_snippet_load_by_area``
+=============================
+
+Returns the selected snippet from the webspace settings for the given snippet area.
+
+.. code-block:: jinja
+
+    {% set snippets = sulu_snippet_load_by_area('sidebar_overview') %}
+    {{ snippets.content.title }}
+
+**Arguments**:
+
+- **area**: *string* - The area to search for snippet.
+- **webspaceKey**: *string* - optional: The webspace to get area snippet settings.
+- **locale**: *string* - optional: The locale to load snippet.
+
+**Returns**:
+
+.. include:: _snippet_structure.inc

--- a/reference/twig-extensions/functions/sulu_snippet_load_default.rst
+++ b/reference/twig-extensions/functions/sulu_snippet_load_default.rst
@@ -1,12 +1,16 @@
 ``sulu_snippet_load_default``
 =============================
 
+.. note::
+
+    This method is deprecated, use :doc:`sulu_snippet_load_by_area` instead.
+
 Returns content array of selected default snippet for given snippet type.
 
 .. code-block:: jinja
 
     {% set snippets = sulu_snippet_load_default('default') %}
-    {{ snippets[0].title }}
+    {{ snippets[0].content.title }}
 
 .. note::
 

--- a/reference/twig-extensions/index.rst
+++ b/reference/twig-extensions/index.rst
@@ -41,6 +41,7 @@ SnippetBundle
 
     functions/sulu_snippet_load
     functions/sulu_snippet_load_default
+    functions/sulu_snippet_load_by_area
 
 MediaBundle
 -----------


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Added documentation for snippet areas.

#### Why?

Use the same template definition for multiple default snippets or load them per area key.
