### PR TITLE
Remove // from url content schemes example

### DIFF
--- a/reference/content-types/url.rst
+++ b/reference/content-types/url.rst
@@ -41,7 +41,6 @@ Example
             <param name="schemes" type="collection">
                 <param name="http://"/>
                 <param name="https://"/>
-                <param name="//"/>
             </param>
         </params>
     </property>


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Remove the `//` example from the url content type schemes.

#### Why?


The `//` does crash the sulu url content type and is not recommended to be used.
