### PR TITLE
Fixed typo on contact selection documentation

### DIFF
--- a/reference/content-types/contact_selection.rst
+++ b/reference/content-types/contact_selection.rst
@@ -20,7 +20,7 @@ Parameters
     * - contact
       - boolean
       - Person tab should be visible or not.
-    * - accounts
+    * - account
       - boolean
       - Organizations tab should be visible or not.
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | no issue available
| License | MIT

#### What's in this PR?

There was an typo on parameters in contact selection (`accounts` instead of `account`)

#### Why?

Not a specific one - only for correct documentation.
