### PR TITLE
added varnish opts "-p "vcc_allow_inline_c=on"

### DIFF
--- a/cookbook/caching-with-varnish.rst
+++ b/cookbook/caching-with-varnish.rst
@@ -116,6 +116,7 @@ Under Debiae/Ubuntu we can change the initialization script:
                  -f /etc/varnish/default.vcl \   
                  -S /etc/varnish/secret \        
                  -s malloc,256m 
+                 -p "vcc_allow_inline_c=on"
 
 Now restart the daemon:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | none
| License | MIT

#### What's in this PR?

This PR add the deamon-opt `-p "vcc_allow_inline_c=on"` to varnish config