### PR TITLE
Missing type on Custom Tags

### DIFF
--- a/bundles/markup/index.rst
+++ b/bundles/markup/index.rst
@@ -96,7 +96,7 @@ namespace.
 
     <service id="app.tag" class="AppBundle\CustomTag">
         <tag name="sulu_markup.tag" namespace="custom-namespace"
-             tag="custom-tag"/>
+             tag="custom-tag" type="html" />
     </service>
 
 With this definitions you can use ``<custom-namespace:custom-tag/>`` in your


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| License | MIT

#### What's in this PR?

Fix doc on Custom Tags [MarkupBundle]

#### Why?

Without this tag :
```
In TagCompilerPass.php line 46:
Notice: Undefined index: type  
```