### PR TITLE
Remove assetic integration from the liip theme example config

### DIFF
--- a/book/themes.rst
+++ b/book/themes.rst
@@ -64,7 +64,6 @@ To enable it add the following lines into the `app/AbstractKernel.php` and
         themes: ["default"]
         active_theme: "default"
         load_controllers: false
-        assetic_integration: true
 
 This will configure a default theme which can be enabled in the
 `app/Resources/webspaces/<webspace>.xml` file by adding:


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Remove assetic integration from the liip theme example config.

#### Why?

Assetic requires to be the assetic bundle installed as it is also not recommended to use it we should remove it from the docs.
