### PR TITLE
Cherry-pick relevant 1.6 changes from develop branch

### DIFF
--- a/book/admin-interface.rst
+++ b/book/admin-interface.rst
@@ -20,7 +20,7 @@ implemented search. Just enter whatever you want to work on and it will give you
 Contacts
 --------
 
-Contacts on the one hand cover the handling of personal informations on the other hand they are also
+Contacts on the one hand cover the handling of personal information on the other hand they are also
 the user provider for Sulu Users.
 
 .. figure:: ../img/admin-contact-people.png

--- a/book/image-formats.rst
+++ b/book/image-formats.rst
@@ -54,7 +54,7 @@ The next table shows the standard commands available with its parameters.
 |         |                                    |
 |         | y: y-coordinate of the startpoint  |
 |         |                                    |
-|         | w: the with of the new image       |
+|         | w: the width of the new image      |
 |         |                                    |
 |         | h: the height of the new image     |
 +---------+------------------------------------+

--- a/book/image-formats.rst
+++ b/book/image-formats.rst
@@ -14,18 +14,13 @@ Take a look at the following file for an example:
     <?xml version="1.0" encoding="UTF-8"?>
     <formats xmlns="http://schemas.sulu.io/media/formats"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.0.xsd">
-        <format>
-            <name>640x480</name>
-            <commands>
-                <command>
-                    <action>resize</action>
-                    <parameters>
-                        <parameter name="x">640</parameter>
-                        <parameter name="y">480</parameter>
-                    </parameters>
-                </command>
-            </commands>
+             xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">
+        <format key="640x480">
+            <meta>
+                <title lang="de">640x480</title>
+                <title lang="en">640x480</title>
+            </meta>
+            <scale x="640" y="480"/>
             <!-- optional compression for this format -->
             <options>
                 <option name="jpeg_quality">80</option>

--- a/book/introduction/content-architecture.rst
+++ b/book/introduction/content-architecture.rst
@@ -83,7 +83,7 @@ Sulu is very extensible. You got existing content you want to integrate through
 DBAL? Do it. An API that delivers content? Integrate it. Other Symfony bundles
 you've already coded. Integrate them.
 
-A more detailled documentation could be found in the section
+A more detailed documentation could be found in the section
 :doc:`../content-architecture`.
 
 Now you are really deep into the concepts of Sulu. So the next step is to get

--- a/book/introduction/index.rst
+++ b/book/introduction/index.rst
@@ -18,6 +18,6 @@ to do things the way we do them.
     backend-template
     content-architecture
 
-It is important to understand the underlaying concepts of Sulu,
+It is important to understand the underlying concepts of Sulu,
 but if you want to skip this part and start coding, head over
 to :doc:`../getting-started`.

--- a/book/twig.rst
+++ b/book/twig.rst
@@ -145,7 +145,7 @@ contexts might be enough:
 
 The following screenshot shows the `Sulu homepage`_ with the main navigation on
 the right and the footer navigation on the bottom. As you can see the
-navigations returned for the navigation contexts are not necessarily flat, but
+navigation returned for the navigation contexts are not necessarily flat, but
 can also contain sub pages.
 
 .. figure:: ../img/website-navigation-contexts.png

--- a/bundles/admin/ckeditor.rst
+++ b/bundles/admin/ckeditor.rst
@@ -1,9 +1,9 @@
 CKEditor
 ========
 
-The build in editor CKEditor has a quite powerfull plugin system. This can be
+The build in editor CKEditor has a quite powerful plugin system. It can be
 used to create additional toolbar-buttons and dialogs. Sulu gives you the
-ability to add this plugins in your bundle.
+ability to add these as plugins to your bundle.
 
 Example
 -------
@@ -131,11 +131,11 @@ http://docs.ckeditor.com/#!/guide/plugin_sdk_sample_1.
         };
     });
 
-2. Register plugin
-******************
+2. Register your new plugin
+***************************
 
-In you main.js file of your bundle you can require the before created plugin and
-register it in the ``initialize`` function.
+In the main.js file of your bundle you can require the newly created plugin and register it through the ``initialize``
+function.
 
 .. code-block:: javascript
 
@@ -146,11 +146,10 @@ register it in the ``initialize`` function.
         new Abbr(app.sandboxes.create('plugin-abbr'))
     );
 
-You can now use you plugin in all ckeditors.
+You can now use your plugin in all Ckeditor instances.
 
 .. note::
 
-    To create your overlays or other plugins in our aura-system you can also
-    use the sandbox to start your own component. But be aware that you have to
-    be sure that you stop all your components to reduce the memory-usage and
-    usage of the event-system.
+    To create your overlays or other plugins in our aura-system you can also use the sandbox to start your own
+    component. But you have to be sure that you did stop all your components to reduce the memory-usage and calls to the
+    event-system.

--- a/bundles/admin/javascript-hooks/collaboration.rst
+++ b/bundles/admin/javascript-hooks/collaboration.rst
@@ -1,7 +1,7 @@
 Collaboration
 =============
 
-The collaboration-hook initializes collabation-component. This component is able
+The collaboration-hook initializes collaboration-component. This component is able
 to communicate with the server and determine which user is currently working on
 the same record.
 

--- a/bundles/admin/javascript-hooks/header.rst
+++ b/bundles/admin/javascript-hooks/header.rst
@@ -111,7 +111,7 @@ List of all available options:
       - an object of options to pass to the husky-toolbar-component
     * - toolbar.languageChanger
       - Object|Boolean
-      - contains configuration-properties for the language-changer dropdown. If just set to ``true`` renderes
+      - contains configuration-properties for the language-changer dropdown. If just set to ``true`` renders
         a dropdown with the system-locales and emits events as a callback
     * - toolbar.languageChanger.url
       - String

--- a/bundles/admin/javascript-hooks/load-component-data.rst
+++ b/bundles/admin/javascript-hooks/load-component-data.rst
@@ -7,12 +7,12 @@ of your component startup and continuing only after the data has been loaded.
 The load-component-data-hook simplifies this task. Within the return-object of a
 javascript-component, you can specify a ``loadComponentData`` method where you load your data. This method must
 return a promise or your desired data straight away. If such a method is specified
-the AdminBundle delays the startup of your component and sets ``this.data`` with your laoded data
+the AdminBundle delays the startup of your component and sets ``this.data`` with your loaded data
 (where ``this`` is the context of your component). So when your components ``initialize`` method
 gets called you can conveniently access your data via ``this.data`` and don't have to worry
 about asynchronicity.
 
-So the ``loadComponentData`` and ``initialize`` method of your component would look somthing like:
+So the ``loadComponentData`` and ``initialize`` method of your component would look something like:
 
 .. code-block:: javascript
 

--- a/bundles/content/security.rst
+++ b/bundles/content/security.rst
@@ -13,7 +13,7 @@ this page. The other toolbar items are only available if the user has the
 `edit` permission.
 
 The column navigation for the content is a bit more complicated. The entire
-tree is always visible, but the available funcationality is changing based on
+tree is always visible, but the available functionality is changing based on
 the permissions of the page. The `delete` permission is tied to the delete
 item in the option dropdown. The `edit` permission is required to move and sort
 the page in the content tree. For sorting the page the `edit` permission of all
@@ -24,7 +24,7 @@ page.
 
 In addition to that the icon appearing on hovering one of the items in the
 content tree depends on its permission. If the user is allowed to edit the page
-a pencil shows up, in case the user has only ther permission to view the page
+a pencil shows up, in case the user has only the permission to view the page
 an eyes is shown instead. In case the user has no permission at all, there also
 will not appear any icon on hovering.
 

--- a/bundles/markup/index.rst
+++ b/bundles/markup/index.rst
@@ -96,7 +96,7 @@ namespace.
 
     <service id="app.tag" class="AppBundle\CustomTag">
         <tag name="sulu_markup.tag" namespace="custom-namespace"
-             tag="custom-tag"/>
+             tag="custom-tag" type="html" />
     </service>
 
 With this definitions you can use ``<custom-namespace:custom-tag/>`` in your

--- a/bundles/route/index.rst
+++ b/bundles/route/index.rst
@@ -34,7 +34,7 @@ available on the website with an own route.
 Entity
 ******
 
-First extend your entity with the propertie's `id`, `locale` and a new many-to-one relation `route`:
+First extend your entity with the properties `id`, `locale` and a new many-to-one relation `route`:
 
 reciepe.orm.xml:
 

--- a/bundles/security.rst
+++ b/bundles/security.rst
@@ -13,7 +13,7 @@ SuluContactBundle. In addition to that a user can have some roles and groups
 assigned, whereby a group can consist of multiple other groups and roles.
 
 Every role has to be part of a certain system. Different systems can be
-registrated via the security contexts, which are explained later. These systems
+registered via the security contexts, which are explained later. These systems
 correspond to different applications handled by Sulu. So by default there is
 only the ``Sulu`` system. A user is only enabled to login into Sulu, if he has
 at least one role with the ``Sulu`` system assigned.
@@ -66,7 +66,7 @@ grants access.
 Access Control Manager
 ----------------------
 
-The ``AccessControlManager`` is reponsible to set permissions on specific
+The ``AccessControlManager`` is responsible to set permissions on specific
 objects. Since this is not totally decoupled from the entity being protected,
 there is the possibility to register multiple ``AccessControlProvider``. This
 is simply a service implementing the ``AccessControlProviderInterface`` tagged
@@ -103,7 +103,7 @@ the ``SecurityContextVoter``.
 This voter will check if the user is allowed to perform the given action (the
 permissions already listed above) in the given context in the given locale. If
 the object type and id are also passed the permissions of the security contexts
-from the role might be overriden by the permissions from this specific object
+from the role might be overridden by the permissions from this specific object
 (which are handled by the previously mentioned ``AccessControlManager``).
 
 .. _security mechanisms of Symfony: http://symfony.com/doc/current/book/security.html

--- a/bundles/website/reference-store.rst
+++ b/bundles/website/reference-store.rst
@@ -26,7 +26,7 @@ Example
 .. code-block:: xml
 
     <service id="app.reference_store.example"
-             class="Sulu\Bundle\ContentBundle\ReferenceStore\ReferenceStore">
+             class="Sulu\Bundle\WebsiteBundle\ReferenceStore\ReferenceStore">
         <tag name="sulu_website.reference_store" alias="example"/>
     </service>
 

--- a/cookbook/custom-error-page.rst
+++ b/cookbook/custom-error-page.rst
@@ -56,7 +56,7 @@ Following variables are usable inside the exception template.
 | `status_code`                   | http-status-code                                                 |
 | `status_text`                   | http-status-code message                                         |
 | `exception`                     | complete exception object                                        |
-| `currentContent`                | repsonse content which were rendered bofore exception was thrown |
+| `currentContent`                | response content which were rendered before exception was thrown |
 | `urls`                          | localized urls to start page (e.g. for language-switcher)        |
 | `request.webspaceKey`           | key of the current webspace                                      |
 | `request.defaultLocale`         | default locale of current portal                                 |

--- a/cookbook/custom-urls.rst
+++ b/cookbook/custom-urls.rst
@@ -16,7 +16,7 @@ A custom-url consists of following properties:
     * - Parameter
       - Description
     * - Title
-      - This title will be displayed in the list and should identify the usecase
+      - This title will be displayed in the list and should identify the use case
         of this url.
     * - Activated
       - This flag indicates if the custom-url is shown on the website.

--- a/cookbook/dump-sitemap.rst
+++ b/cookbook/dump-sitemap.rst
@@ -1,7 +1,7 @@
 Improve Sitemap Speed
 =====================
 
-The sitemap of Sulu is based on small pieces, wich are generated
+The sitemap of Sulu is based on small pieces, which are generated
 by so called `SitemapProvider` (see :doc:`sitemap-provider`).
 Each provider returns mostly 50000 links which can return many
 links, which would take a bigger amount of time. The Google bot

--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -41,6 +41,7 @@ our recipes.
     sitemap-provider
     dump-sitemap
     enable-adobe-creative-suite
+    video-preview-images
 
 It is possible to work through the recipes, although most of the people will
 pick the ones, which are most similar to their own tasks. We're open to

--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -42,6 +42,6 @@ our recipes.
     dump-sitemap
     enable-adobe-creative-suite
 
-It is possible to work through the recepies, altought most of the people will
+It is possible to work through the recipes, although most of the people will
 pick the ones, which are most similar to their own tasks. We're open to
 `suggestions <http://sulu.io/en/contact>`_.

--- a/cookbook/integrating-custom-filters.rst
+++ b/cookbook/integrating-custom-filters.rst
@@ -4,7 +4,7 @@ Integrating custom filters
 When you want to enable custom filters for your bundle you have to follow the 
 following steps. It's important to know that the filter component works with 
 contexts. This means for example that the lists of contacts has the 
-`contacts` context and everything concering the filters for the list will 
+`contacts` context and everything concerning the filters for the list will
 need this context. It should therefore be unique.
 
 Add the missing data types to the field descriptors
@@ -12,7 +12,7 @@ Add the missing data types to the field descriptors
 
 The custom filter feature uses the field descriptors you've already defined for 
 your lists. To work as expected you should define the type of each column. If
-not defined the filter component will asume it's a string. The available data 
+not defined the filter component will assume it's a string. The available data
 types are:
 
 - `string`

--- a/cookbook/securing-your-application.rst
+++ b/cookbook/securing-your-application.rst
@@ -1,7 +1,7 @@
 Securing your application
 =========================
 
-Sulu is delivered with two different possiblities to protect parts of your
+Sulu is delivered with two different possibilities to protect parts of your
 application. The first is the permissions based on security contexts, which
 allow you to restrict access to entire parts of your application or Sulu. The
 permissions for this kind of security are managed on a roles level. In addition
@@ -82,7 +82,7 @@ Protect your controller
 
 After defining a security context, you can use it to easily protect the actions
 of one of your controllers. All you have to do is to implement the
-``SecuredControllerInterface`` telling the ``SuluSecuriyListener`` which
+``SecuredControllerInterface`` telling the ``SuluSecurityListener`` which
 security context and locale to use for the permission check:
 
 .. code-block:: php

--- a/cookbook/sitemap-provider.rst
+++ b/cookbook/sitemap-provider.rst
@@ -26,7 +26,7 @@ Example
 -------
 
 This is a simple example which assumes that the logic to load entities is
-implemented in the Respository.
+implemented in the Repository.
 
 .. code-block:: php
 

--- a/cookbook/system-collections.rst
+++ b/cookbook/system-collections.rst
@@ -31,7 +31,7 @@ This structure will be used to create a Collection Structure like this:
     System
      |--> Sulu contact
      |     |--> People
-     |     |--> Orginizations
+     |     |--> Organizations
      |--> Client Website
            |--> My own System-Collection
 

--- a/cookbook/video-preview-images.rst
+++ b/cookbook/video-preview-images.rst
@@ -1,0 +1,41 @@
+Generating thumbnails for video files with ffmpeg
+=================================================
+
+FFmpeg is a library to process video files. Sulu is able to use this libraries
+to generate thumbnail images for video files.
+
+1. Install ffmpeg-bundle:
+
+.. code-block:: bash
+
+    composer require pulse00/ffmpeg-bundle
+
+2. Add bundle to `app/AbstractKernel.php`:
+
+.. code-block:: php
+
+     abstract class AbstractKernel extends SuluKernel
+     {
+         public function registerBundles()
+         {
+             $bundles = [
+                 ...
+
+                 new Dubture\FFmpegBundle\DubtureFFmpegBundle(),
+             ];
+
+             return $bundles;
+        }
+
+        ...
+    }
+
+3. Add configuration `app/config/config.yml`:
+
+.. code-block:: yaml
+
+    dubture_f_fmpeg:
+        ffmpeg_binary: /usr/local/bin/ffmpeg # path to ffmpeg
+        ffprobe_binary: /usr/local/bin/ffprobe # path to ffprobe
+        binary_timeout: 300 # Use 0 for infinite
+        threads_count: 4

--- a/developer/behat/context-reference.rst
+++ b/developer/behat/context-reference.rst
@@ -39,7 +39,7 @@ The following is not a fully comprehensive list:
   a husky drop-down selector as identified by selector.
 - ``I fill in husky field ":name" with ":value"``: Fill in a husky field (husky
   fields do not have ``name`` elements preventing us from using the default
-  mechanisim).
+  mechanism).
 - ``I click the button ":text"``: Click the button containing the text ``:text``
 - ``I click toolbar item ":id"``: Click on the toolbar item with given id (also dropdown)
 - ``I expect the ":event" event``: Wait for the named aura event

--- a/developer/behat/getting-started.rst
+++ b/developer/behat/getting-started.rst
@@ -110,5 +110,5 @@ Further more you can filter for specific tests using the ``name`` option:
 The above will run all scenarios in the ``contact`` suite which contain the word
 ``Create``.
 
-.. _Selenium: htto://www.seleniumhq.org
+.. _Selenium: http://www.seleniumhq.org
 .. _download selenium server from here: http://www.seleniumhq.org/download/

--- a/developer/contributing/index.rst
+++ b/developer/contributing/index.rst
@@ -33,5 +33,5 @@ just submit the PR and we will review it.
     adding-translations
 
 .. _Symfony coding standards: http://symfony.com/doc/current/contributing/code/standards.html
-.. _pull request: hhttps://help.github.com/articles/using-pull-requests
+.. _pull request: https://help.github.com/articles/using-pull-requests
 .. _Symfony documentation standard: http://symfony.com/doc/current/contributing/documentation/standards.html

--- a/developer/contributing/test-your-code.rst
+++ b/developer/contributing/test-your-code.rst
@@ -1,7 +1,7 @@
 Test your Code
 ==============
 
-Sulu has three types of tests: Unit, Functional and Sceneario (i.e. "Behat").
+Sulu has three types of tests: Unit, Functional and Scenario (i.e. "Behat").
 
 If your tests require external dependencies (e.g. a database connection) then
 they are Functional tests, otherwise they will be a Unit Test.

--- a/reference/components/document-manager/debugging.rst
+++ b/reference/components/document-manager/debugging.rst
@@ -2,7 +2,7 @@ Debugging
 =========
 
 One of the disadvantages of an event based system is that tracking what
-happends and when it happens can be tricky. The Document Manager provides some
+happens and when it happens can be tricky. The Document Manager provides some
 tools to ameliorate this problem.
 
 Subscriber Debug Command
@@ -30,7 +30,7 @@ the following command:
 Here we list all of the subscribers which will be executed when a `remove`
 event is fired.
 
-A full list of events can be retrived if you ommit the argument:
+A full list of events can be retrieved if you omit the argument:
 
 .. code-block:: bash
 

--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -93,7 +93,7 @@ the fixtures:
 
     $ php app/console sulu:document:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2
 
-You can also specify if fixturs should be *appended* (i.e. the repository will
+You can also specify if fixtures should be *appended* (i.e. the repository will
 not be purged) and if the initializer should be executed.
 
 Append fixtures:

--- a/reference/components/document-manager/introduction.rst
+++ b/reference/components/document-manager/introduction.rst
@@ -24,7 +24,7 @@ The following is an example:
 If you are familiar with Doctrine this will seem very familiar. There are some
 differences however:
 
-- Persist commits the chagnes to the *node* immediately, changes made to the
+- Persist commits the changes to the *node* immediately, changes made to the
   document later on will not be taken into account on `flush()`. It is better
   to think of `persist()` as a function which prepares a `snapshot` of the
   current state of the document to be persisted.

--- a/reference/components/document-manager/subscribers.rst
+++ b/reference/components/document-manager/subscribers.rst
@@ -291,7 +291,7 @@ ShadowLocale
 
 **Behavior**: ``Sulu\Component\Content\Document\Behavior\ShadowLocaleBehavior``
 
-The implementing document will have the possiblity to enable a "shadow
+The implementing document will have the possibility to enable a "shadow
 locale" and load its content from a different locale within the same document.
 
 StructureTypeFiling

--- a/reference/content-types/contact_selection.rst
+++ b/reference/content-types/contact_selection.rst
@@ -20,7 +20,7 @@ Parameters
     * - contact
       - boolean
       - Person tab should be visible or not.
-    * - accounts
+    * - account
       - boolean
       - Organizations tab should be visible or not.
 

--- a/reference/content-types/text_editor.rst
+++ b/reference/content-types/text_editor.rst
@@ -36,7 +36,7 @@ Parameters
       
 Texteditor supports also all `ckeditor config`_ parameters in snakecase.
 
-.. _ckeditor config: http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg
+.. _ckeditor config: https://docs.ckeditor.com/ckeditor4/latest/api/CKEDITOR_config.html
 
 Example
 -------

--- a/reference/glossary.rst
+++ b/reference/glossary.rst
@@ -1,7 +1,7 @@
 Glossary
 ========
 
-A glossay is:
+A glossary is:
 
      A list of terms in a particular domain of knowledge with their definitions.
 
@@ -29,7 +29,7 @@ Localized
     Of a Property - the state of being localized, or capable of being translated.
 
 Metadata
-    Literalaly data about data. Typically a data structure with information
+    Literally data about data. Typically a data structure with information
     such as field mappings which should be applied to a different data
     structure.
 
@@ -70,7 +70,7 @@ Resource locator
     resource locator will never include the locale.
 
 Segment
-    As applying to URLs and Paths - a section of a path or URL, preseumably
+    As applying to URLs and Paths - a section of a path or URL, presumably
     delimited by `/`.
 
 Shadow

--- a/reference/index.rst
+++ b/reference/index.rst
@@ -1,8 +1,8 @@
 Reference
 =========
 
-In our reference we'll describe how to configure stuff and how to use existing things. You can find list of funcionality we put in Sulu and how you could use it. At the moment there are `components <components/index.html>`_, `Content Types <content-types/index.html>`_ and `Twig Extensions <twig-extensions/index.html>`_.
-The Reference aims to developers who already worked through the introdcution and know how Sulu works.
+In our reference we'll describe how to configure stuff and how to use existing things. You can find list of functionality we put in Sulu and how you could use it. At the moment there are `components <components/index.html>`_, `Content Types <content-types/index.html>`_ and `Twig Extensions <twig-extensions/index.html>`_.
+The Reference aims to developers who already worked through the introduction and know how Sulu works.
 
 .. figure:: ../img/mrsulu-thinks.jpg
 	:align: center

--- a/reference/twig-extensions/functions/sulu_navigation_flat.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_flat.rst
@@ -7,7 +7,7 @@ Returns navigation from the given page in a flat list data-structure.
 
 - **uuid**: *string* The uuid for which the navigation should be loaded
 - **context**: *string* - optional: context to filter navigation
-- **depth**: *integer* - optional: depth to load (1 - childs, 2 - childs and child of childs, ...)
+- **depth**: *integer* - optional: depth to load (1 - one level deep, 2 - two levels deep, ...)
 - **loadExcerpt**: *boolean* - optional: load data from excerpt tab
 
 **Returns**:

--- a/reference/twig-extensions/functions/sulu_navigation_root_flat.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_root_flat.rst
@@ -6,7 +6,7 @@ Returns navigation from root in a flat list data-structure.
 **Arguments**:
 
 - **context**: *string* - optional: context to filter navigation
-- **depth**: *integer* - optional: depth to load (1 - childs, 2 - childs and child of childs, ...)
+- **depth**: *integer* - optional: depth to load (1 - one level deep, 2 - two levels deep, ...)
 - **loadExcerpt**: *boolean* - optional: load data from excerpt tab
 
 **Returns**:

--- a/reference/twig-extensions/functions/sulu_navigation_root_tree.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_root_tree.rst
@@ -6,7 +6,7 @@ Returns navigation from root in a tree data-structure.
 **Arguments**:
 
 - **context**: *string* - optional: context to filter navigation
-- **depth**: *integer* - optional: depth to load (1 - childs, 2 - childs and child of childs, ...)
+- **depth**: *integer* - optional: depth to load (1 - one level deep, 2 - two levels deep, ...)
 - **loadExcerpt**: *boolean* - optional: load data from excerpt tab
 
 **Returns**:

--- a/reference/twig-extensions/functions/sulu_navigation_tree.rst
+++ b/reference/twig-extensions/functions/sulu_navigation_tree.rst
@@ -7,7 +7,7 @@ Returns navigation from the given page in a tree data-structure.
 
 - **uuid**: *string* The uuid for which the navigation should be loaded
 - **context**: *string* - optional: context to filter navigation
-- **depth**: *integer* - optional: depth to load (1 - childs, 2 - childs and child of childs, ...)
+- **depth**: *integer* - optional: depth to load (1 - one level deep, 2 - two levels deep, ...)
 - **loadExcerpt**: *boolean* - optional: load data from excerpt tab
 
 **Returns**:


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Cherry-pick relevant 1.6 changes from develop branch. See https://github.com/sulu/sulu-docs/compare/master...develop (the only thing which is not included is the http cache refractoring which is only for 2.0)

#### Why?

Currently there are documentations only in the develop branch which are also relevant for the 1.6 version.


### `ATTENTION: This PR should NOT be "Squash merged" else it will conflict later!`
