### PR TITLE
Fix example to get the displayOption from a media

### DIFF
--- a/book/twig.rst
+++ b/book/twig.rst
@@ -111,7 +111,7 @@ in your template. As an example the ``media_selection`` stores the
 
 .. code-block:: html
 
-    {{ view.media[0].displayOption }}
+    {{ view.media.displayOption }}
 
 Other Variables
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Fix example to get the displayOption from a media.

#### Why?

The example is incorrect for getting the displayOption of the media.