### PR TITLE
Clarified checkbox type toggler example.

### DIFF
--- a/reference/content-types/checkbox.rst
+++ b/reference/content-types/checkbox.rst
@@ -17,7 +17,7 @@ Parameters
       - Description
     * - type
       - string
-      - Defines the look of the checkbox, can either be "checkbox" or "toggler"
+      - Defines the look of the checkbox, can either be "checkbox" or "toggler". Be aware of the difference between property type and parameter type.
 
 Example
 -------
@@ -28,4 +28,7 @@ Example
         <meta>
             <title lang="en">Available</title>
         </meta>
+        <params>
+            <param name="type" value="toggler"/>
+        </params>
     </property>

--- a/reference/content-types/checkbox.rst
+++ b/reference/content-types/checkbox.rst
@@ -20,7 +20,7 @@ Parameters
       - Defines the look of the checkbox, can either be "checkbox" or "toggler". Be aware of the difference between property type and parameter type.
 
 Examples
--------
+-----------
 
 .. code-block:: xml
 

--- a/reference/content-types/checkbox.rst
+++ b/reference/content-types/checkbox.rst
@@ -19,7 +19,7 @@ Parameters
       - string
       - Defines the look of the checkbox, can either be "checkbox" or "toggler". Be aware of the difference between property type and parameter type.
 
-Example
+Examples
 -------
 
 .. code-block:: xml
@@ -27,6 +27,14 @@ Example
     <property name="available" type="checkbox">
         <meta>
             <title lang="en">Available</title>
+        </meta>
+    </property>
+
+.. code-block:: xml
+
+    <property name="available" type="checkbox">
+        <meta>
+            <title lang="en">Show Author</title>
         </meta>
         <params>
             <param name="type" value="toggler"/>

--- a/reference/content-types/checkbox.rst
+++ b/reference/content-types/checkbox.rst
@@ -20,7 +20,7 @@ Parameters
       - Defines the look of the checkbox, can either be "checkbox" or "toggler". Be aware of the difference between property type and parameter type.
 
 Examples
------------
+--------
 
 .. code-block:: xml
 


### PR DESCRIPTION
#### What's in this PR?

Expanded the checkbox type example.

#### Why?

I made the mistake to use toggler as property type and not as param. This extension should prevent confusion.
