### PR TITLE
Simplifiy webserver documentation

### DIFF
--- a/cookbook/web-server/built-in.rst
+++ b/cookbook/web-server/built-in.rst
@@ -11,30 +11,25 @@ configuring a full-featured web server such as :doc:`Apache <apache>` or
     The built-in web server is meant to be run in a controlled environment. It
     is not designed to be used on public networks.
 
-The server can be started with the ``server:start`` command. You will have to
-start two different servers for the administration and the website:
+The server can be started with the ``server:start`` command.
 
 .. code-block:: bash
 
-    bin/adminconsole server:start
-    bin/websiteconsole server:start
+    bin/console server:start
 
-These commands will start two servers listening on http://127.0.0.1:8000 and
-http://127.0.0.1:8001 in the background.
+These commands will start a server listening on http://127.0.0.1:8000.
 
 You can change the IP and port of the web servers by passing them as argument:
 
 .. code-block:: bash
 
-    bin/adminconsole server:start 192.168.0.1:8080
-    bin/websiteconsole server:start 192.168.0.1:8081
+    bin/console server:start 192.168.0.1:8080
 
 The server can be stopped again with the ``server:stop`` command:
 
 .. code-block:: bash
 
-    bin/adminconsole server:stop
-    bin/websiteconsole server:stop
+    bin/console server:stop
 
 Read the `Symfony documentation on the built-in web server`_ to learn more about
 the different ``server:*`` commands and options.

--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -45,14 +45,14 @@ The Nginx configuration could look something like.
       }
 
       # pass the PHP scripts to FastCGI server from upstream phpfcgi
-      location ~ ^/(website|admin|app|app_dev|config)\.php(/|$) {
-          include fastcgi_params;
-          fastcgi_pass unix:/var/run/php5-fpm.sock;
-          fastcgi_buffers 16 16k;
-          fastcgi_buffer_size 32k;
+      location ~ ^/(website|admin|app|config)\.php(/|$) {
+          fastcgi_pass unix:/var/run/php7.1-fpm.sock;
           fastcgi_split_path_info ^(.+\.php)(/.*)$;
-          fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+          include fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+          fastcgi_param DOCUMENT_ROOT $realpath_root;
           fastcgi_param SYMFONY_ENV dev;
+          internal;
       }
   }
 


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Simplifiy webserver documentation for the 1.6 version.
And updated nginx config with recommendation from symfony https://symfony.com/doc/current/setup/web_server_configuration.html#nginx 

#### Why?

Starting two webservers are not longer needed for the php internal server.
