### PR TITLE
Added code blocks to webspace docs and updated maintenance mode documentation

### DIFF
--- a/cookbook/create-new-webspace.rst
+++ b/cookbook/create-new-webspace.rst
@@ -3,7 +3,7 @@ Adding new Webspace
 
 To create a new webspace you have to create a new file within the
 `app/Resources/webspaces` directory. The content of the file should be quite
-similar to the `sulu_io.xml.dist` file in this folder.
+similar to the `example.com.xml`_ file in this folder.
 
 .. note::
 
@@ -13,10 +13,14 @@ similar to the `sulu_io.xml.dist` file in this folder.
 To activate the webspace within sulu with a `prod` or `stage` environment
 you have to clear the cache with the command:
 
+.. code-block:: bash
+
     $ php bin/adminconsole cache:clear -e <environment>
 
 Afterwards you will need to initialize the new webspace, to do so run the
 following command:
+
+.. code-block:: bash
 
     $ php bin/adminconsole sulu:document:initialize
 
@@ -27,4 +31,8 @@ After this few steps you are able to administrate and view your new webspace.
 
 If you have any error you can use the following command to validate your webspace:
 
-    $ php bin/adminconsole sulu:content:validate:webspaces
+.. code-block:: bash
+
+     $ php bin/adminconsole sulu:content:validate:webspaces
+
+.. _example.com.xml: https://github.com/sulu/sulu-minimal/blob/1.6.22/app/Resources/webspaces/example.com.xml

--- a/cookbook/maintenance-mode.rst
+++ b/cookbook/maintenance-mode.rst
@@ -7,21 +7,24 @@ about it.
 
 Sulu maintenance mode displays a simple holding page which can be easily customized.
 
-Create Maintenance Mode
------------------------
+Activate Maintenance Mode
+-------------------------
 
-To create a maintenance page, you first need to create a ``maintenance.php`` file:
+Sulu is shipped with a simple maintenance page stored in `app/maintenance.php`_
+file which can be changed for your needs.
 
-.. code-block:: bash
-
-    $ cp app/maintenance.php.dist app/maintenance.php
-
-Then you need to set the environment variable SULU_MAINTENANCE to true.
-For example, in your ``.htaccess`` file (for apache)
+To activate the maintenance mode you need to  set the environment variable SULU_MAINTENANCE to true.
+For example, in your ``.htaccess`` file or vhost file for apache:
  
 .. code-block:: apache
 
     SetEnv SULU_MAINTENANCE true
+
+For nginx you can configure the maintenance mode in the php part of your vhost by adding:
+
+.. code-block:: nginx
+
+    fastcgi_param SULU_MAINTENANCE true;
 
 Configure Maintenance Mode
 --------------------------
@@ -64,3 +67,5 @@ exists the default locale is being used. By default this is English:
 
     <?php
     define('DEFAULT_LOCALE', 'en');
+
+.. _app/maintenance.php: https://github.com/sulu/sulu-minimal/blob/1.6.22/app/maintenance.php


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Added code blocks to webspace docs and updated maintenance mode documentation

#### Why?

Code blocks are more readable for commands. 
Maintenance mode documentation was not longer correct.
