### PR TITLE
Updated console calls to new console usage of php

### DIFF
--- a/bundles/content/drafting.rst
+++ b/bundles/content/drafting.rst
@@ -69,7 +69,7 @@ if you want to start e.g. the `PHPCR Shell`_:
 
 .. code-block:: bash
 
-    app/console doctrine:phpcr:shell --session=live
+    php bin/console doctrine:phpcr:shell --session=live
 
 If you want to start the `PHPCR Shell`_ with the ``default_session`` you can
 simply omit the ``--session`` parameter.
@@ -83,8 +83,8 @@ You do so by using two different console commands:
 
 .. code-block:: bash
 
-    app/console massive:search:reindex # Reindex the default session
-    app/webconsole massive:search:reindex # Reindex the live session
+    php bin/console massive:search:reindex # Reindex the default session
+    php bin/websiteconsole massive:search:reindex # Reindex the live session
 
 .. _PHPCR: http://phpcr.github.io/
 .. _PHPCR Shell: http://phpcr.readthedocs.io/en/latest/phpcr-shell/

--- a/bundles/route/index.rst
+++ b/bundles/route/index.rst
@@ -181,5 +181,5 @@ simple call the `save` method of the service `sulu_route.manager.route_manager`.
 .. note::
 
     To update already existing entities you can run the command
-    `bin/console sulu:route:update AppBundle:Recipe` which updates or creates
+    `php bin/console sulu:route:update AppBundle:Recipe` which updates or creates
     the route for all the entities of this type.

--- a/bundles/search.rst
+++ b/bundles/search.rst
@@ -132,12 +132,12 @@ simply run the following:
 
 .. code-block:: bash
 
-    $ ./app/console massive:search:reindex --env=prod
+    $ php bin/console massive:search:reindex --env=prod
 
 .. warning::
 
     At the moment it is required to also execute
-    `./app/webconsole massive:search:reindex --env=prod` to reindex the pages
+    `php bin/websiteconsole massive:search:reindex --env=prod` to reindex the pages
     also for the website.
 
 This may take anywhere between a minute and several hours depending on how

--- a/cookbook/websocket.rst
+++ b/cookbook/websocket.rst
@@ -38,9 +38,13 @@ by placing the following lines into your configuration:
 Execution
 ---------
 
-To execute the websocket you have to run the command
-``app/console sulu:websocket:run -e prod``. This command starts the server and
-listens to the configured port.
+To execute the websocket you have to run the command the following command:
+
+.. code-block:: bash
+
+    php bin/console sulu:websocket:run -e prod`
+
+This command starts the server and listens to the configured port.
 
 We recommend to run the websocket with `supervisor <http://supervisord.org/>`_.
 You can use the example configuration for supervisord.
@@ -50,7 +54,7 @@ You can use the example configuration for supervisord.
 .. code-block:: ini
 
     [program:sulu_websocket]
-    command=/var/www/sulu.io/app/console sulu:websocket:run --env prod
+    command=/var/www/sulu.io/bin/console sulu:websocket:run --env prod
     process_name=sulu_websocket
     user=www-data
     numprocs=1

--- a/developer/contributing/adding-translations.rst
+++ b/developer/contributing/adding-translations.rst
@@ -61,9 +61,13 @@ in the standard edition of Sulu:
 
 #. Add the 2-letter code to the array ``sulu_core.translations``
 
-#. Build the new language using
-   ``app/console sulu:translate:export [language]``. If you updated
-   multiple languages at once, you can leave off the `language` part.
+#. Build the new language using the following command:
+
+.. code-block:: bash
+
+    php bin/console  sulu:translate:export [language]
+
+If you updated multiple languages at once, you can leave off the `language` part.
 
 Afterwards commit all the changes and create Pull Requests as described in
 :doc:`pull-requests`.

--- a/reference/components/document-manager/debugging.rst
+++ b/reference/components/document-manager/debugging.rst
@@ -14,7 +14,7 @@ the following command:
 
 .. code-block:: bash
 
-    $ ./app/console sulu:document:subscriber:debug remove
+    $ php bin/console sulu:document:subscriber:debug remove
     +--------------------------------------------------------------------------+------------------+----------+
     | Class                                                                    | Method           | Priority |
     +--------------------------------------------------------------------------+------------------+----------+
@@ -34,7 +34,7 @@ A full list of events can be retrieved if you omit the argument:
 
 .. code-block:: bash
 
-    $ ./app/console sulu:document:subscriber:debug
+    $ php bin/console sulu:document:subscriber:debug
     +----------------------+
     | Event                |
     +----------------------+

--- a/reference/components/document-manager/fixtures.rst
+++ b/reference/components/document-manager/fixtures.rst
@@ -74,7 +74,7 @@ command.
 
 .. code-block:: bash
 
-    $ php app/console sulu:document:fixtures:load
+    $ php bin/console sulu:document:fixtures:load
 
 By default this command will purge and re-initialize the workspace before
 loading all of the fixtures.
@@ -91,7 +91,7 @@ the fixtures:
 
 .. code-block:: bash
 
-    $ php app/console sulu:document:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2
+    $ php bin/console sulu:document:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2
 
 You can also specify if fixtures should be *appended* (i.e. the repository will
 not be purged) and if the initializer should be executed.
@@ -100,13 +100,13 @@ Append fixtures:
 
 .. code-block:: bash
 
-    $ php app/console sulu:document:fixtures:load --append
+    $ php bin/console sulu:document:fixtures:load --append
 
 Do not initialize:
 
 .. code-block:: bash
 
-    $ php app/console sulu:document:fixtures:load --no-initialize
+    $ php bin/console sulu:document:fixtures:load --no-initialize
 
 Using the Service Container
 ---------------------------


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Updated console calls to new console usage of php.

#### Why?

The `app/console`  does not longer exist and calling it with php is required on some systems.
