### PR TITLE
Added a missing backslack in /etc/default/varnish

### DIFF
--- a/cookbook/caching-with-varnish.rst
+++ b/cookbook/caching-with-varnish.rst
@@ -115,7 +115,7 @@ Under Debiae/Ubuntu we can change the initialization script:
                  -T localhost:6082 \             
                  -f /etc/varnish/default.vcl \   
                  -S /etc/varnish/secret \        
-                 -s malloc,256m 
+                 -s malloc,256m \
                  -p "vcc_allow_inline_c=on"
 
 Now restart the daemon:


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | N/A
| License | MIT

#### What's in this PR?

A backslash was missing from the varnish startup config.