### PR TITLE
Added documentation about default_host on sitemap-generation

### DIFF
--- a/cookbook/dump-sitemap.rst
+++ b/cookbook/dump-sitemap.rst
@@ -22,4 +22,4 @@ properly configured the ``default_host`` parameter.
 
 .. code-block:: bash
 
-    `bin/websiteconsole sulu:website:dump-sitemap`
+    bin/websiteconsole sulu:website:dump-sitemap

--- a/cookbook/dump-sitemap.rst
+++ b/cookbook/dump-sitemap.rst
@@ -10,6 +10,16 @@ Therefore Sulu is able to pre-generate the whole sitemap and
 cache it on the filesystem. This can be triggered by calling the
 following command. This can also be done by a cron-job.
 
+Before you start generating the sitemap, make sure that you have
+properly configured the ``default_host`` parameter.
+
+.. code-block:: yaml
+
+    sulu_website:
+        sitemap:
+            default_host: http://example.com
+
+
 .. code-block:: bash
 
-    app/websiteconsole sulu:website:dump-sitemap
+    `bin/websiteconsole sulu:website:dump-sitemap`


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### What's in this PR?

Documentation improvement for sitemap-generation and required _default_host_ param.

#### Why?

https://github.com/sulu/sulu/issues/3732
and corrected command according to the _develop_ branch.
