### PR TITLE
Fix nginx vhost for ipv6

### DIFF
--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -7,6 +7,7 @@ The Nginx configuration could look something like.
 
   server {
       listen 80;
+      listen [::]:80;
 
       server_name sulu.lo;
       root /var/www/sulu.lo/web;


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| License | MIT

#### What's in this PR?

Fix nginx vhost for ipv6.

#### Why?

The example vhost will currently not work with ipv6.
