### PR TITLE
Remove X-Cache-Tags header when not in X-Cache-Debug mode.

### DIFF
--- a/cookbook/caching-with-varnish.rst
+++ b/cookbook/caching-with-varnish.rst
@@ -215,6 +215,7 @@ The following will add full caching support for Sulu:
         if (!resp.http.x-cache-debug) {
             unset resp.http.x-url;
             unset resp.http.x-host;
+            unset resp.http.x-cache-tags;
         }
 
         if (obj.hits > 0) {


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #425
| License | MIT

#### What's in this PR?

Added configuration example how to remove X-Cache-Tags from the response headers.

#### Why?

The X-Cache-Tags header can be rreally big.