### PR TITLE
Add nginx file upload doc

### DIFF
--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -63,7 +63,7 @@ The Nginx configuration could look something like.
 File upload
 -----------
 
-By default the nginx has a file limit of 2M when uploading files.
+By default nginx has a file limit of 2MB when uploading files.
 To increase this add the following to your ``nginx.conf``:
 
 .. code-block:: xml

--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -60,5 +60,23 @@ The Nginx configuration could look something like.
 .. warning::
     Be sure to also configure your local host-file, if running Sulu locally.
 
-.. include:: file-permissions.inc.rst
+File upload
+-----------
 
+By default the nginx has a file limit of 2M when uploading files.
+To increase this add the following to your ``nginx.conf``:
+
+.. code-block:: xml
+
+    # ...
+
+    http {
+        client_max_body_size 512m;
+
+        # ...
+    }
+
+Don't forget to also increase the ``post_max_size`` and ``upload_max_filesize`` in
+your ``php.ini``.
+
+.. include:: file-permissions.inc.rst


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| License | MIT

#### What's in this PR?

Add documentation how to increase the uploaded max filesize in nginx.

#### Why?

It seems to be a common issue when using nginx in front of sulu as nginx
default value is 2M