### PR TITLE
Add single media selection content type documentation

### DIFF
--- a/reference/content-types/index.rst
+++ b/reference/content-types/index.rst
@@ -61,6 +61,7 @@ content type:
     internal_links
     location
     media_selection
+    single_media_selection
     contact_selection
     password
     phone

--- a/reference/content-types/single_media_selection.rst
+++ b/reference/content-types/single_media_selection.rst
@@ -1,0 +1,78 @@
+Single Media selection
+======================
+
+Description
+-----------
+
+Shows a list with the possibility to assign a single asset from the media section
+to a page. Also allows to define a position, which can be handled later in the
+template.
+
+Parameters
+----------
+
+.. list-table::
+    :header-rows: 1
+
+    * - Parameter
+      - Type
+      - Description
+    * - types
+      - string
+      - A comma separated list of available asset types to assign. Each item in
+        the list must be one of ``document``, ``image``, ``video`` or ``audio``.
+    * - displayOptions
+      - collection
+      - A collection of booleans, which defines to which positions the assets
+        can be assigned (``leftTop``, ``top``, ``rightTop``, ...)
+    * - defaultDisplayOption
+      - string
+      - Defines which of the displayOptions is the default one
+    * - formats
+      - collection
+      - A collection of image formats, which will be available when opening the
+        cropping overlay in the page form. Contains all image formats by default.
+
+Example
+-------
+
+.. code-block:: xml
+
+    <property name="document" type="single_media_selection">
+        <meta>
+            <title lang="en">Document</title>
+        </meta>
+    </property>
+
+Extended Example
+----------------
+
+.. code-block:: xml
+
+    <property name="image" type="single_media_selection">
+        <meta>
+            <title lang="en">Image</title>
+        </meta>
+
+        <params>
+            <param name="types" value="image,video"/>
+
+            <param name="displayOptions" type="collection">
+                <param name="leftTop" value="true"/>
+                <param name="top" value="true"/>
+                <param name="rightTop" value="true"/>
+                <param name="left" value="true"/>
+                <param name="middle" value="false"/>
+                <param name="right" value="true"/>
+                <param name="leftBottom" value="true"/>
+                <param name="bottom" value="true"/>
+                <param name="rightBottom" value="true"/>
+            </param>
+
+            <param name="defaultDisplayOption" value="left"/>
+
+            <param name="formats" type="collection">
+                <param name="640x960" />
+            </param>
+        </params>
+    </property>


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Add single media selection content type documentation

#### Why?

Was implemented by @nnatter in https://github.com/sulu/sulu/pull/4281/files
