### PR TITLE
Rename snippet content type to snippet_selection

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -211,7 +211,7 @@ Here is a table with the content types shipped in Sulu core:
 | |teaser_selection|           | widget for displaying content teasers       | array containing array representations  |
 |                              |                                             | of the teasers                          |
 +------------------------------+---------------------------------------------+-----------------------------------------+
-| |snippet|                    | widget for selecting snippets               | array containing array representations  |
+| |snippet_selection|          | widget for selecting snippets               | array containing array representations  |
 |                              |                                             | of the snippets                         |
 +------------------------------+---------------------------------------------+-----------------------------------------+
 | |single_contact_selection|   | widget for selecting a single contact       | ContactInterface                        |
@@ -920,5 +920,5 @@ with :doc:`twig` to learn more about rendering this structure as HTML.
 .. |checkbox| replace:: :doc:`checkbox <../reference/content-types/checkbox>`
 .. |select| replace:: :doc:`multiple_select <../reference/content-types/select>`
 .. |single_select| replace:: :doc:`single_select <../reference/content-types/single_select>`
-.. |snippet| replace:: :doc:`snippet <../reference/content-types/snippet>`
-.. |single_contact_selection| replace:: :doc:`snippet <../reference/content-types/single_contact_selection>`
+.. |snippet_selection| replace:: :doc:`snippet_selection <../reference/content-types/snippet_selection>`
+.. |single_contact_selection| replace:: :doc:`single_contact_selection <../reference/content-types/single_contact_selection>`

--- a/cookbook/default-snippets.rst
+++ b/cookbook/default-snippets.rst
@@ -50,7 +50,7 @@ The default snippets will be used if the following conditions are fulfilled.
 
 1. The feature has to be activated (`sulu_snippet.types.snippet.default_enabled`) (default activated since 1.4)
 2. The snippet-selection parameter ``default`` has to be
-   defined. See :doc:`../reference/content-types/snippet`.
+   defined. See :doc:`../reference/content-types/snippet_selection`.
 3. The snippet for the configured area has to be selected in the
    webspace settings.
 

--- a/reference/content-types/index.rst
+++ b/reference/content-types/index.rst
@@ -72,7 +72,7 @@ content type:
     single_account_selection
     single_media_selection
     smart_content
-    snippet
+    snippet_selection
     tag_selection
     teaser_selection
     text_area

--- a/reference/content-types/snippet_selection.rst
+++ b/reference/content-types/snippet_selection.rst
@@ -1,5 +1,5 @@
-Snippet
-=======
+Snippet Selection
+=================
 
 Description
 -----------
@@ -37,7 +37,7 @@ Example
 
 .. code-block:: xml
 
-    <property name="snippets" type="snippet">
+    <property name="snippets" type="snippet_selection">
         <meta>
             <title lang="en">Snippets</title>
         </meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| License | MIT

#### What's in this PR?

Rename snippet content type to snippet_selection.

#### Why?

Content types should be normalized for 2.0 https://github.com/sulu/sulu/pull/4565.
