### PR TITLE
Renamed smart content types in documentation and change sulu-link tags

### DIFF
--- a/bundles/markup/index.rst
+++ b/bundles/markup/index.rst
@@ -8,7 +8,7 @@ before the response will be sent.
 Example
 -------
 
-This example contains a sulu-related example. The tag ``sulu:link`` represents
+This example contains a sulu-related example. The tag ``sulu-link`` represents
 a link to another page. This tag will be replaced via a valid anchor where the
 `href` attribute contains the UUID of the page.
 
@@ -16,7 +16,7 @@ a link to another page. This tag will be replaced via a valid anchor where the
 
     <html>
         <body>
-            <sulu:link href="123-123-123" title="test-title" />
+            <sulu-link href="123-123-123" title="test-title" />
         </body>
     </html>
 
@@ -99,5 +99,5 @@ namespace.
              tag="custom-tag" type="html" />
     </service>
 
-With this definitions you can use ``<custom-namespace:custom-tag/>`` in your
+With this definitions you can use ``<custom-namespace-custom-tag/>`` in your
 response.

--- a/bundles/markup/link.rst
+++ b/bundles/markup/link.rst
@@ -1,4 +1,4 @@
-sulu:link
+sulu-link
 =========
 
 The link tag provides the possibility to link to other pages by uuid. This uuid
@@ -9,8 +9,8 @@ Example
 
 .. code-block:: html
 
-    <sulu:link href="123-123-123" title="test-title" />
-    <sulu:link href="123-123-123" target="_blank">Link Text</sulu:link>
+    <sulu-link href="123-123-123" title="test-title" />
+    <sulu-link href="123-123-123" target="_blank">Link Text</sulu-link>
 
 **Results into:**
 

--- a/bundles/markup/media.rst
+++ b/bundles/markup/media.rst
@@ -1,4 +1,4 @@
-sulu:media
+sulu-media
 ==========
 
 The media tag provides the possibility to create download links for medias.
@@ -8,9 +8,9 @@ Example
 
 .. code-block:: html
 
-    <sulu:media id="1" title="Title"/>
-    <sulu:media id="1" title="Title">Link-Text</sulu:media>
-    <sulu:media id="1">Link-Text</sulu:media>
+    <sulu-media id="1" title="Title"/>
+    <sulu-media id="1" title="Title">Link-Text</sulu-media>
+    <sulu-media id="1">Link-Text</sulu-media>
 
 **Results into:**
 

--- a/cookbook/link-provider.rst
+++ b/cookbook/link-provider.rst
@@ -10,7 +10,7 @@ chapter :doc:`../bundles/markup/index`).
 
 .. code-block:: html
 
-    <sulu:link provider="page" href="123-123-123"/>
+    <sulu-link provider="page" href="123-123-123"/>
 
 
 The LinkItem consists of the following properties:

--- a/reference/content-types/smart_content.rst
+++ b/reference/content-types/smart_content.rst
@@ -151,7 +151,7 @@ These providers are predefined for Sulu-Entities.
 Content Pages
 ~~~~~~~~~~~~~
 
-Alias: "content"
+Alias: "pages"
 
 This provider filters content pages. You can choose a parent page as data
 source, whose child pages will be filtered by the DataProvider.
@@ -203,14 +203,14 @@ This provider filters snippets.
 Contact - People
 ~~~~~~~~~~~~~~~~
 
-Alias: "contact"
+Alias: "contacts"
 
 This provider filters the contacts.
 
 Account - Organization
 ~~~~~~~~~~~~~~~~~~~~~~
 
-Alias: "account"
+Alias: "accounts"
 
 This provider filters the accounts.
 
@@ -262,7 +262,7 @@ Page template
         </meta>
 
         <params>
-            <param name="provider" value="content"/>
+            <param name="provider" value="pages"/>
             <param name="max_per_page" value="5"/>
             <param name="page_parameter" value="p"/>
             <param name="properties" type="collection">

--- a/reference/content-types/smart_content.rst
+++ b/reference/content-types/smart_content.rst
@@ -181,7 +181,7 @@ source, whose child pages will be filtered by the DataProvider.
 Snippet
 ~~~~~~~
 
-Alias: "snippet"
+Alias: "snippets"
 
 This provider filters snippets.
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets |
| License | MIT

#### What's in this PR?

Renamed the aliases of the smart_content types

#### Why?

Because it changed in Sulu 2.0
