### PR TITLE
Code example corrected

### DIFF
--- a/reference/content-types/single_select.rst
+++ b/reference/content-types/single_select.rst
@@ -61,6 +61,6 @@ You can use symfony expression language to access values from a service.
         </meta>
 
         <params>
-            <param name="values" expression="service('your_service').getValues()"/>
+            <param name="values" type="expression" value="service('your_service').getValues()"/>
         </params>
     </property>


### PR DESCRIPTION
#### Why?

The code example showing the usage of symfony expression language contained incorrect parameters.
