### PR TITLE
Change sulu/sulu-minimal reference to sulu/skeleton

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -7,12 +7,12 @@ and... go!
 Bootstrap a Project
 -------------------
 
-We'll bootstrap a new project based on the `Sulu Minimal Edition`_ with
+We'll bootstrap a new project based on the `Sulu Skeleton`_ with
 Composer_:
 
 .. code-block:: bash
 
-    composer create-project sulu/sulu-minimal my-project -n
+    composer create-project sulu/skeleton my-project -n
 
 This command will bootstrap a new project in the directory ``my-project``.
 
@@ -151,7 +151,7 @@ play around.
 
 When you're ready to learn more, continue with :doc:`templates`.
 
-.. _Sulu Minimal Edition: https://github.com/sulu/sulu-minimal
-.. _Composer:  https://getcomposer.org
+.. _Sulu Skeleton: https://github.com/sulu/skeleton
+.. _Composer: https://getcomposer.org
 .. _supported by Doctrine DBAL: http://doctrine-orm.readthedocs.io/projects/doctrine-dbal/en/latest/reference/platforms.html
 .. _Apache Jackrabbit: http://jackrabbit.apache.org

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -25,7 +25,7 @@ Each page template is defined by two files:
 
 For example, the default template -- named "default" -- is defined by the files
 ``config/templates/pages/default.xml`` and
-``templates/pages/default.html.twig``. The Sulu Minimal Edition
+``templates/pages/default.html.twig``. The Sulu Skeleton
 also contains a second template named "homepage", which you can find in the
 same directories.
 
@@ -879,11 +879,11 @@ The tag can have specific attributes:
 
 **Types**:
 
- - `string`: For simple fields 
+ - `string`: For simple fields
  - `array`: For multiple fields such as the `category_selection` content type
  - `tags`: Special typ for `tag_selection` content type
  - `date`: For indexing the `date` content type
- - `json`: For indexing raw data in the search 
+ - `json`: For indexing raw data in the search
 
 Next Steps
 ----------

--- a/cookbook/create-new-webspace.rst
+++ b/cookbook/create-new-webspace.rst
@@ -33,4 +33,4 @@ If you have any error you can use the following command to validate your webspac
 
     $ php bin/adminconsole sulu:content:validate:webspaces
 
-.. _example.xml: https://github.com/sulu/sulu-minimal/blob/develop/config/webspaces/example.xml
+.. _example.xml: https://github.com/sulu/skeleton/blob/master/config/webspaces/example.xml

--- a/cookbook/maintenance-mode.rst
+++ b/cookbook/maintenance-mode.rst
@@ -10,12 +10,12 @@ Sulu maintenance mode displays a simple holding page which can be easily customi
 Activate Maintenance Mode
 -------------------------
 
-Sulu is shipped with a simple maintenance page stored in `app/maintenance.php`_
+Sulu is shipped with a simple maintenance page stored in `public/maintenance.php`_
 file which can be changed for your needs.
 
 To activate the maintenance mode you need to  set the environment variable SULU_MAINTENANCE to true.
 For example, in your ``.htaccess`` file or vhost file for apache:
- 
+
 .. code-block:: apache
 
     SetEnv SULU_MAINTENANCE true
@@ -60,7 +60,7 @@ You can define translations for your template as follows:
 Default locale
 ~~~~~~~~~~~~~~
 
-By default, ``maintenance.php`` is automatically detecting your browsers language. If no translation for this language 
+By default, ``maintenance.php`` is automatically detecting your browsers language. If no translation for this language
 exists the default locale is being used. By default this is English:
 
 .. code-block:: php
@@ -68,4 +68,4 @@ exists the default locale is being used. By default this is English:
     <?php
     define('DEFAULT_LOCALE', 'en');
 
-.. _app/maintenance.php: https://github.com/sulu/sulu-minimal/blob/1.6.22/app/maintenance.php
+.. _public/maintenance.php: https://github.com/sulu/skeleton/blob/master/public/maintenance.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| License | MIT

#### What's in this PR?

Change all references from sulu-minimal to skeleton

#### Why?

The new template to start a sulu project is now called [skeleton](https://github.com/sulu/skeleton) like symfony/skeleton ...

#### TODO

 - [x] https://github.com/sulu/skeleton
