### PR TITLE
Fix default-type attribute value in block.rst

### DIFF
--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -44,7 +44,7 @@ editor as described in the description.
 
 .. code-block:: xml
 
-    <block name="blocks" default-type="editor" minOccurs="0">
+    <block name="blocks" default-type="editor_image" minOccurs="0">
         <meta>
             <title lang="de">Inhalte</title>
             <title lang="en">Content</title>


### PR DESCRIPTION
fixed default-type attribute value to match example type name
