### PR TITLE
added configuration hint to configure enum mapping_types for doctrine

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -95,6 +95,16 @@ Here is an example for using Sulu with MySQL:
 
     DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name
 
+You might need to adjust your ``config/packages/doctrine.yaml`` file to add a mapping for enums:
+
+.. code-block:: yaml
+
+   doctrine:
+    dbal:
+        # ... 
+        mapping_types:
+            enum: string
+
 When you're done with the configuration, populate the database with Sulu's
 default data:
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Added a configuration hint how to add a mapping type to support enums (need for mysql 5.7.23)

#### Why?

Unable to run the installation command `bin/adminconsole sulu:build dev`
