### PR TITLE
Update Smart Content documentation for Sulu 2.0

### DIFF
--- a/reference/content-types/smart_content.rst
+++ b/reference/content-types/smart_content.rst
@@ -33,7 +33,7 @@ Parameters
       - Description
     * - provider
       - string
-      - DataProvider alias for content of SmartContent - Default 'content'.
+      - DataProvider alias for content of SmartContent - Default 'pages'.
     * - max_per_page
       - integer
       - Limits the results per page. Omit this parameter to disable pagination.


### PR DESCRIPTION
Fixed a place, where the old provider 'content' has not been replaced with 'pages' yet.

| Q | A
| --- | ---
| Fixed tickets | none
| License | MIT

#### What's in this PR?

Removed remaining old smart content provider and replaced with new one.

#### Why?

The provider 'content' has been replaced with the 'pages' provider in Sulu 2.0 but documentation is still showing old provider.
