### PR TITLE
Update content-repository.rst

### DIFF
--- a/bundles/page/content-repository.rst
+++ b/bundles/page/content-repository.rst
@@ -65,7 +65,7 @@ default.
 Service
 .......
 
-The id of the service is `sulu_content.content_repository`. The methods can be
+The id of the service is `sulu_page.content_repository`. The methods can be
 used as described in the phpdocs.
 
 The mapping variable contains information for the mapping process.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes 
| License | MIT

#### What's in this PR?

Fixes the documentation

#### Why?

The Content Repository Service name in the docs is `sulu_content.content_repository` and should be `sulu_page.content_repository`