### PR TITLE
Improve docs for adding new webspace

### DIFF
--- a/cookbook/create-new-webspace.rst
+++ b/cookbook/create-new-webspace.rst
@@ -10,12 +10,11 @@ similar to the `example.xml`_ file in this folder.
     The key of the webspace has to be the same as the filename without the xml
     extension.
 
-To activate the webspace within sulu with a `prod` or `stage` environment
-you have to clear the cache with the command:
+To activate the webspace within sulu you have to clear the cache with the command:
 
 .. code-block:: bash
 
-    $ php bin/adminconsole cache:clear -e <environment>
+    $ php bin/adminconsole cache:clear
 
 Afterwards you will need to initialize the new webspace, to do so run the
 following command:
@@ -30,6 +29,8 @@ the roles for the new webspace.
 After this few steps you are able to administrate and view your new webspace.
 
 If you have any error you can use the following command to validate your webspace:
+
+.. code-block:: bash
 
     $ php bin/adminconsole sulu:content:validate:webspaces
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| License | MIT

#### What's in this PR?

Remove -e from cache:clear command for adding new webspace.

#### Why?

Most commands are just copy & pasted and in symfony 4 its not longer the case that the `APP_ENV` is different to the env in console as it is defined in the `.env.local` file or as the container environment variable. 
