### PR TITLE
Remove web server bundle commands from docs

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -33,7 +33,7 @@ This command will bootstrap a new project in the directory ``my-project``.
     If you want to use other languages than english or german for the
     administration interface of Sulu you need to configure them in the
     ``config/packages/sulu_admin.yaml`` file:
-    
+
     .. code-block:: yaml
 
         sulu_core:
@@ -152,7 +152,7 @@ will make sure the correct application is loaded.
 
 .. code-block:: bash
 
-    bin/console server:start
+    php -S localhost:8000 -t public/
 
 You can access the administration interface via http://127.0.0.1:8000/admin.
 The default user and password is "admin".

--- a/cookbook/web-server/built-in.rst
+++ b/cookbook/web-server/built-in.rst
@@ -1,6 +1,11 @@
 How to Use PHP's built-in Web Server
 ====================================
 
+.. note::
+
+    Symfony provides a more feature rich web server for development.
+    Read the `Symfony documentation on the symfony server`_ to learn more about.
+
 PHP (>= 5.4) comes with a `built-in web server`_. This server can be used to
 run your Sulu application during development. This way, you don't have to bother
 configuring a full-featured web server such as :doc:`Apache <apache>` or
@@ -11,11 +16,11 @@ configuring a full-featured web server such as :doc:`Apache <apache>` or
     The built-in web server is meant to be run in a controlled environment. It
     is not designed to be used on public networks.
 
-The server can be started with the ``server:start`` command.
+The server can be started with the following command.
 
 .. code-block:: bash
 
-    bin/console server:start
+    php -S localhost:8000 -t public/
 
 These commands will start a server listening on http://127.0.0.1:8000, resp.
 the first free port after 8000.
@@ -24,16 +29,7 @@ You can change the IP and port of the web servers by passing them as argument:
 
 .. code-block:: bash
 
-    bin/console server:start 192.168.0.1:8080
-
-The server can be stopped again with the ``server:stop`` command:
-
-.. code-block:: bash
-
-    bin/console server:stop
-
-Read the `Symfony documentation on the built-in web server`_ to learn more about
-the different ``server:*`` commands and options.
+    php -S 192.168.0.1:8080 -t public/
 
 .. _built-in web server: http://www.php.net/manual/en/features.commandline.webserver.php
-.. _Symfony documentation on the built-in web server: http://symfony.com/doc/current/setup/built_in_web_server.html
+.. _Symfony documentation on the symfony server: https://symfony.com/doc/current/setup/symfony_server.html


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| Related PRs | https://github.com/sulu/sulu/pull/5187
| License | MIT

#### What's in this PR?

Remove web server bundle commands from docs.

#### Why?

WebServerBundle is deprecated and should not longer be used and will not support Symfony 5.
