### PR TITLE
Adjust documentation to use new router script

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -152,7 +152,7 @@ will make sure the correct application is loaded.
 
 .. code-block:: bash
 
-    php -S localhost:8000 -t public/
+    php -S localhost:8000 -t public/ config/router.php
 
 You can access the administration interface via http://127.0.0.1:8000/admin.
 The default user and password is "admin".

--- a/cookbook/web-server/built-in.rst
+++ b/cookbook/web-server/built-in.rst
@@ -20,7 +20,7 @@ The server can be started with the following command.
 
 .. code-block:: bash
 
-    php -S localhost:8000 -t public/
+    php -S localhost:8000 -t public/ config/router.php
 
 These commands will start a server listening on http://127.0.0.1:8000, resp.
 the first free port after 8000.
@@ -29,7 +29,7 @@ You can change the IP and port of the web servers by passing them as argument:
 
 .. code-block:: bash
 
-    php -S 192.168.0.1:8080 -t public/
+    php -S 192.168.0.1:8080 -t public/ config/router.php
 
 .. _built-in web server: http://www.php.net/manual/en/features.commandline.webserver.php
 .. _Symfony documentation on the symfony server: https://symfony.com/doc/current/setup/symfony_server.html


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | ---
| Related PRs | sulu/sulu#5192
| License | MIT

#### What's in this PR?

This PR adds the router script to the call of the php builtin webserver.

#### Why?

Because otherwise the image rendering functionality does not work.