### PR TITLE
Highlight hint for adding permissions to user role after creating webspace

### DIFF
--- a/cookbook/create-new-webspace.rst
+++ b/cookbook/create-new-webspace.rst
@@ -23,8 +23,10 @@ following command:
 
     $ php bin/adminconsole sulu:document:initialize
 
-To allow users to see the new webspace you also have to set the permissions in
-the roles for the new webspace.
+.. note::
+
+    To allow users to see the new webspace you also have to add the permissions for the
+    webspace to the respective roles.
 
 After this few steps you are able to administrate and view your new webspace.
 


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### Why?

It feels like forgetting about this is a common mistake, Maybe highlighting the hint helps 🙂 
