### PR TITLE
Remove currentContent from error twig parameters

### DIFF
--- a/cookbook/custom-error-page.rst
+++ b/cookbook/custom-error-page.rst
@@ -58,8 +58,6 @@ Following variables are usable inside the exception template.
 +---------------------------------+------------------------------------------------------------------+
 | `exception`                     | complete exception object                                        |
 +---------------------------------+------------------------------------------------------------------+
-| `currentContent`                | response content which were rendered before exception was thrown |
-+---------------------------------+------------------------------------------------------------------+
 | `urls`                          | localized urls to start page (e.g. for language-switcher)        |
 +---------------------------------+------------------------------------------------------------------+
 | `request.webspaceKey`           | key of the current webspace                                      |


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| Related PRs | sulu/sulu#5266
| License | MIT

#### What's in this PR?

Remove currentContent from error twig parameters.

build on top of: https://github.com/sulu/sulu-docs/pull/516.

#### Why?

Remove the not longer available currentContent parameter.
