### PR TITLE
Add warning that values expression of select is only evaluated on initial request

### DIFF
--- a/reference/content-types/select.rst
+++ b/reference/content-types/select.rst
@@ -64,7 +64,7 @@ You can use symfony expression language to access values from a service.
 
 .. note::
 
-    Be aware the the provided expression is only evaluated during the initial request to the administration interface.
+    Be aware that the provided expression is only evaluated during the initial request to the administration interface.
     If you want to provide a selection for your custom entity, you should configure the ``selection`` field-type as
     described in :doc:`../../book/extend-admin`.
 

--- a/reference/content-types/select.rst
+++ b/reference/content-types/select.rst
@@ -62,6 +62,12 @@ Example
 
 You can use symfony expression language to access values from a service.
 
+.. note::
+
+    Be aware the the provided expression is only evaluated during the initial request to the administration interface.
+    If you want to provide a selection for your custom entity, you should configure the ``selection`` field-type as
+    described in :doc:`../../book/extend-admin`.
+
 .. code-block:: xml
 
     <property name="list" type="select">

--- a/reference/content-types/single_select.rst
+++ b/reference/content-types/single_select.rst
@@ -55,7 +55,7 @@ You can use symfony expression language to access values from a service.
 
 .. note::
 
-    Be aware the the provided expression is only evaluated during the initial request to the administration interface.
+    Be aware that the provided expression is only evaluated during the initial request to the administration interface.
     If you want to provide a selection for your custom entity, you should configure the ``single_selection`` field-type
     as described in :doc:`../../book/extend-admin`.
 

--- a/reference/content-types/single_select.rst
+++ b/reference/content-types/single_select.rst
@@ -53,6 +53,12 @@ Example
 
 You can use symfony expression language to access values from a service.
 
+.. note::
+
+    Be aware the the provided expression is only evaluated during the initial request to the administration interface.
+    If you want to provide a selection for your custom entity, you should configure the ``single_selection`` field-type
+    as described in :doc:`../../book/extend-admin`.
+
 .. code-block:: xml
 
     <property name="single" type="single_select">


### PR DESCRIPTION
#### What's in this PR?

This PR adds a warning that the values expression of the `select` and `single_select` content type is only evaluated during the initial request.

#### Why?

Because this is a common misconception in our Slack channel 🙂 