### PR TITLE
 Add recommended security headers and cache lifetime

### DIFF
--- a/cookbook/web-server/apache.rst
+++ b/cookbook/web-server/apache.rst
@@ -56,22 +56,27 @@ Let's add the Apache configuration file for the `sulu.lo` domain.
 
           <IfModule mod_expires.c>
               ExpiresActive On
-              ExpiresByType image/gif "access plus 1 month"
-              ExpiresByType image/png "access plus 1 month"
-              ExpiresByType image/svg+xml "access plus 1 month"
-              ExpiresByType image/svg "access plus 1 month"
-              ExpiresByType image/jpeg "access plus 1 month"
-              ExpiresByType image/jpg "access plus 1 month"
-              ExpiresByType image/webp "access plus 1 month"
-              ExpiresByType image/x-icon "access plus 1 month"
-              ExpiresByType image/vnd.microsoft.icon "access plus 1 month"
-              ExpiresByType text/javascript "access plus 1 month"
-              ExpiresByType text/css "access plus 1 month"
-              ExpiresByType font/woff2 "access plus 1 month"
-              ExpiresByType font/woff "access plus 1 month"
-              ExpiresByType font/eot "access plus 1 month"
-              ExpiresByType font/ttf "access plus 1 month"
-              ExpiresByType video/mp4 "access plus 1 month"
+              ExpiresByType image/gif "access plus 1 year"
+              ExpiresByType image/png "access plus 1 year"
+              ExpiresByType image/svg+xml "access plus 1 year"
+              ExpiresByType image/svg "access plus 1 year"
+              ExpiresByType image/jpeg "access plus 1 year"
+              ExpiresByType image/jpg "access plus 1 year"
+              ExpiresByType image/webp "access plus 1 year"
+              ExpiresByType image/x-icon "access plus 1 year"
+              ExpiresByType image/vnd.microsoft.icon "access plus 1 year"
+              ExpiresByType text/javascript "access plus 1 year"
+              ExpiresByType text/css "access plus 1 year"
+              ExpiresByType font/woff2 "access plus 1 year"
+              ExpiresByType font/woff "access plus 1 year"
+              ExpiresByType font/eot "access plus 1 year"
+              ExpiresByType font/ttf "access plus 1 year"
+              ExpiresByType video/mp4 "access plus 1 year"
+
+              # recommended security headers
+              Header set X-Content-Type-Options "nosniff"
+              Header set X-Frame-Options "sameorigin"
+              Header set X-XSS-Protection "1; mode=block"
           </IfModule>
 
           <IfModule mod_deflate.c>

--- a/cookbook/web-server/nginx.rst
+++ b/cookbook/web-server/nginx.rst
@@ -18,6 +18,11 @@ The Nginx configuration could look something like.
       # strip app.php/ prefix if it is present
       rewrite ^/app\.php/?(.*)$ /$1 permanent;
 
+      # recommended security headers
+      add_header X-Frame-Options sameorigin;
+      add_header X-Content-Type-Options nosniff;
+      add_header X-XSS-Protection "1; mode=block";
+
       location /admin {
           index admin.php;
           try_files $uri @rewriteadmin;
@@ -36,7 +41,7 @@ The Nginx configuration could look something like.
       location ~* \.(?:ico|css|js|gif|webp|jpe?g|png|svg|woff|woff2|eot|ttf|mp4)$ {
           try_files $uri /website.php/$1?$query_string;
           access_log off;
-          expires 30d;
+          expires 1y;
           add_header Pragma public;
           add_header Cache-Control "public";
       }


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related PRs | requires: sulu/sulu#535
| License | MIT

#### What's in this PR?

Add recommended security headers:

```bash
X-Frame-Options: sameorigin;
X-Content-Type-Options: nosniff;
X-XSS-Protection: "1; mode=block";
```

and increase the cachelifetime of static assets to **1 year** which is recommended by google.

#### Why?

Security and cache recomendations
