### PR TITLE
Fix cache lifetime for javascript in apache vhost

### DIFF
--- a/cookbook/web-server/apache.rst
+++ b/cookbook/web-server/apache.rst
@@ -65,6 +65,7 @@ Let's add the Apache configuration file for the `sulu.lo` domain.
               ExpiresByType image/webp "access plus 1 year"
               ExpiresByType image/x-icon "access plus 1 year"
               ExpiresByType image/vnd.microsoft.icon "access plus 1 year"
+              ExpiresByType application/javascript "access plus 1 year"
               ExpiresByType text/javascript "access plus 1 year"
               ExpiresByType text/css "access plus 1 year"
               ExpiresByType font/woff2 "access plus 1 year"


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

It seems like some version of apache still return javascript as `application/javascript` instead of `text/javascript`.

E.g.: `curl -XGET "https://sulu.io/website/build/js/main.js?v=1.0.254" -I | grep 'Content-Type'`

#### Why?

That javascript files are not cached by the browser.