### PR TITLE
Fix controller naming for Symfony 5

### DIFF
--- a/book/twig.rst
+++ b/book/twig.rst
@@ -19,7 +19,7 @@ In :doc:`templates` we learned how to define a template.
         <key>default</key>
 
         <view>templates/default</view>
-        <controller>SuluWebsiteBundle:Default:index</controller>
+        <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
         ...
     </template>
 

--- a/reference/content-types/index.rst
+++ b/reference/content-types/index.rst
@@ -16,7 +16,7 @@ The simplest template possible looks something like the this:
         <key>default</key>
 
         <view>ClientWebsiteBundle:templates:default</view>
-        <controller>SuluWebsiteBundle:Default:index</controller>
+        <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
         <cacheLifetime>2400</cacheLifetime>
 
         <meta>


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | 
| Related PRs | 
| License | MIT

#### What's in this PR?

A fix of the docs that is required for Symfony 5.

#### Why?

This PR fixes issues _Controller "SuluWebsiteBundle:Default:index" does neither exist as service nor as class_ errors when upgrading from 2.0 to Sulu 2.1 (the skeleton generates these correctly but the docs still use the old controller naming that no longer works in Symfony 5).
