### PR TITLE
Update Routing Bundle Doc to Symfony 4.4

### DIFF
--- a/bundles/route/index.rst
+++ b/bundles/route/index.rst
@@ -125,9 +125,9 @@ RecipeController
     namespace AppBundle\Controller;
 
     use AppBundle\Entity\Recipe;
-    use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-    class RecipeController extends Controller
+    class RecipeController extends AbstractController
     {
         public function indexAction(Recipe $recipe)
         {


### PR DESCRIPTION
#### What's in this PR?

The "Controller" class is removed with Symfony 4. 
https://symfony.com/doc/4.4/controller.html#the-base-controller-classes-services
Now its "AbstractController" 