### PR TITLE
Add documentation about https

### DIFF
--- a/cookbook/https.rst
+++ b/cookbook/https.rst
@@ -1,7 +1,7 @@
 HTTPS
 =====
 
-Sulu generates URLs in the same way as Symfony does..
+Sulu generates URLs in the same way as Symfony does.
 If the requested protocol is ``https`` it will use automatically ``https`` to generate its URLs.
 
 If this does not work propertly, your setup probably includes some kind of proxy, e.g. a load balancer or a HTTP cache like Varnish.

--- a/cookbook/https.rst
+++ b/cookbook/https.rst
@@ -1,11 +1,11 @@
 HTTPS
 =====
 
-Sulu behave the same way as Symfony when generating urls.
-If the requested protocol is ``https`` it will use automatically ``https`` to generate its urls.
+Sulu generates URLs in the same way as Symfony does..
+If the requested protocol is ``https`` it will use automatically ``https`` to generate its URLs.
 
-If this does not happen its a hint that you are behind a load balancer or have a proxy between your request server.
-In that case you should have a look at the `Symfony Proxy Documentation`_ and configure your trusted proxy ip addresses.
+If this does not work propertly, your setup probably includes some kind of proxy, e.g. a load balancer or a HTTP cache like Varnish.
+In that case you should add the IP address of your trusted proxy as explained in the `Symfony Proxy Documentation`_.
 
 If it still doesn't work you should debug the Symfony `Request::isSecure`_  method,
 which represents which protocol is used by Symfony in its `Request::getScheme`_  method.

--- a/cookbook/https.rst
+++ b/cookbook/https.rst
@@ -1,0 +1,35 @@
+HTTPS
+=====
+
+Sulu behave the same way as Symfony when generating urls.
+If the requested protocol is ``https`` it will use automatically ``https`` to generate its urls.
+
+If this does not happen its a hint that you are behind a load balancer or have a proxy between your request server.
+In that case you should have a look at the `Symfony Proxy Documentation`_ and configure your trusted proxy ip addresses.
+
+If it still doesn't work you should debug the Symfony `Request::isSecure`_  method,
+which represents which protocol is used by Symfony in its `Request::getScheme`_  method.
+
+It is also possible to force the protocol in your vhost of your websebserver:
+
+Apache
+------
+
+Add the following to your apache vhost:
+
+.. code-block:: apache
+
+    SetEnv HTTPS on
+
+Nginx
+-----
+
+Add the following to your nginx vhost php-fpm param configuration:
+
+.. code-block:: nginx
+
+    fastcgi_param HTTPS on;
+
+.. _`Symfony Proxy Documentation`: https://symfony.com/doc/current/deployment/proxies.html
+.. _`Request::isSecure`: https://github.com/symfony/symfony/blob/v5.1.5/src/Symfony/Component/HttpFoundation/Request.php#L1139-L1141
+.. _`Request::getScheme`: https://github.com/symfony/symfony/blob/31b6a95fc288617ccfa27aa819d30c0c2201416a/src/Symfony/Component/HttpFoundation/Request.php#L910-L913

--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -39,6 +39,7 @@ our recipes.
     dump-sitemap
     enable-adobe-creative-suite
     video-preview-images
+    https
 
 It is possible to work through the recipes, although most of the people will
 pick the ones, which are most similar to their own tasks. We're open to


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| Related PRs | -
| License | MIT

#### What's in this PR?

Add documentation about https.

#### Why?

Many times people run into issue that sulu generates `http` instead of `https` urls. I hope this documentation does help people to understand how symfony/sulu choose the protocol to generate the urls.
