### PR TITLE
Add snippet area link and fix seo twig template reference

### DIFF
--- a/book/twig.rst
+++ b/book/twig.rst
@@ -65,7 +65,7 @@ You could include the SEO meta tags like this:
 
 .. code-block:: html
 
-    {% include "SuluWebsiteBundle:Extension:seo.html.twig" with {
+    {% include "@SuluWebsite/Extension/seo.html.twig" with {
         "seo": extension.seo|default([]),
         "content": content|default([]),
         "urls": urls|default([]),

--- a/reference/twig-extensions/functions/sulu_snippet_load_by_area.rst
+++ b/reference/twig-extensions/functions/sulu_snippet_load_by_area.rst
@@ -1,7 +1,7 @@
 ``sulu_snippet_load_by_area``
 =============================
 
-Returns the selected snippet from the webspace settings for the given snippet area.
+Returns the selected snippet from the webspace settings for the given :doc:`snippet area <../../../cookbook/default-snippets>`.
 
 .. code-block:: jinja
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| Related PRs | -
| License | MIT

#### What's in this PR?

Add snippet area link and fix seo twig template reference.

#### Why?

Links are always great, the old templating syntax is not longer supported.
