### PR TITLE
Add twig example to every content type and improve content type docs

### DIFF
--- a/reference/content-types/account_selection.rst
+++ b/reference/content-types/account_selection.rst
@@ -40,11 +40,20 @@ Example
 
 .. code-block:: xml
 
-    <property name="account" type="account_selection">
+    <property name="accounts" type="account_selection">
         <meta>
             <title lang="en">Accounts</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for account in content.accounts %}
+        <h3>{{ account.name }}</h3>
+    {% endif %}
 
 .. _Account: https://github.com/sulu/sulu/blob/master/src/Sulu/Bundle/ContactBundle/Api/Account.php
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -90,8 +90,7 @@ editor as described in the description.
 Twig
 ----
 
-The best way to render a block is having a separate file per type and use the following
-function to achieve this:
+A reusable way for rendering blocks is having a separate template file per type:
 
 .. code-block:: twig
 
@@ -102,5 +101,4 @@ function to achieve this:
         } %}
     {% endfor %}
 
-Inside the rendered function you have again access with ``content`` and ``view`` to the block
-specific ``properties``.
+This way, its possible to access the ``properties`` of the block type  ivia the ``content`` and ``view`` variable in the rendered block template.

--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -56,18 +56,21 @@ editor as described in the description.
             <title lang="de">Inhalte</title>
             <title lang="en">Content</title>
         </meta>
+
         <types>
             <type name="editor_image">
                 <meta>
                     <title lang="de">Editor mit Bild</title>
                     <title lang="en">Editor with image</title>
                 </meta>
+
                 <properties>
                     <property name="images" type="media_selection" colspan="3">
                         <meta>
                             <title lang="de">Bilder</title>
                             <title lang="en">Images</title>
                         </meta>
+
                         <tag name="sulu.block_preview" priority="512"/>
                     </property>
 
@@ -76,9 +79,28 @@ editor as described in the description.
                             <title lang="de">Artikel</title>
                             <title lang="en">Article</title>
                         </meta>
+
                         <tag name="sulu.block_preview" priority="1024"/>
                     </property>
                 </properties>
             </type>
         </types>
     </block>
+
+Twig
+----
+
+The best way to render a block is having a separate file per type and use the following
+function to achieve this:
+
+.. code-block:: twig
+
+    {% for block in content.blocks %}
+        {% include 'includes/blocks/' ~ block.type ~ '.html.twig' with {
+            content: block,
+            view: view.blocks[loop.index0],
+        } %}
+    {% endfor %}
+
+Inside the rendered function you have again access with ``content`` and ``view`` to the block
+specific ``properties``.

--- a/reference/content-types/category_selection.rst
+++ b/reference/content-types/category_selection.rst
@@ -54,4 +54,7 @@ Twig
         <h3>{{ category.name }}</h3>
     {% endif %}
 
+If you want to list all categories of a specific category you can use the :doc:`../twig-extensions/functions/sulu_categories`
+twig extension for it.
+
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/category_selection.rst
+++ b/reference/content-types/category_selection.rst
@@ -10,8 +10,8 @@ section of Sulu. The selection will be saved as an array.
 
 .. note::
 
-    Mostly this content type is not needed as all pages can be categorized over
-    the ``Excerpt and Taxonomies`` tab.
+    This content type is rarely needed because the ``Excerpt and Taxonomies``
+    allows to assign categories to pages.
 
 Parameters
 ----------
@@ -54,7 +54,7 @@ Twig
         <h3>{{ category.name }}</h3>
     {% endif %}
 
-If you want to list all categories of a specific category you can use the :doc:`../twig-extensions/functions/sulu_categories`
+If you want to list all categories in your template you can use the :doc:`../twig-extensions/functions/sulu_categories`
 twig extension for it.
 
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/category_selection.rst
+++ b/reference/content-types/category_selection.rst
@@ -8,6 +8,11 @@ Shows a list of all available categories. The user can select with a checkbox
 which ones to assign to the page. Categories can be managed in the settings
 section of Sulu. The selection will be saved as an array.
 
+.. note::
+
+    Mostly this content type is not needed as all pages can be categorized over
+    the ``Excerpt and Taxonomies`` tab.
+
 Parameters
 ----------
 
@@ -29,7 +34,6 @@ Parameters
       - Collection of property names.
         The value of the respective properties are appended to the requests sent by the selection.
 
-
 Example
 -------
 
@@ -40,5 +44,14 @@ Example
             <title lang="en">Category Selection</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for category in content.categories %}
+        <h3>{{ category.name }}</h3>
+    {% endif %}
 
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/checkbox.rst
+++ b/reference/content-types/checkbox.rst
@@ -22,7 +22,7 @@ Parameters
       - bool
       - Defines the default value of the checkbox. When not set the initial value of the checkbox is null.
     * - label
-      - 
+      -
       - Defines the label of the checkbox. This is recommended if the meta title should be next to the toggler instead of above it.
 
 Examples
@@ -60,3 +60,12 @@ Examples
             </param>
         </params>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% if content.available %}
+        {# ... #}
+    {% endif %}

--- a/reference/content-types/color.rst
+++ b/reference/content-types/color.rst
@@ -22,3 +22,12 @@ Example
             <title lang="en">Color</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    <div style="background-color: {{ content.color }};">
+        Block with specified background color
+    </div>

--- a/reference/content-types/contact_account_selection.rst
+++ b/reference/content-types/contact_account_selection.rst
@@ -24,12 +24,15 @@ Example
         </meta>
     </property>
 
+Twig
+----
+
 .. code-block:: twig
 
     <ul>
         {% for contact in content.contacts %}
             <li>
-                {{ contact.fullName is defined ? contact.fullName : contact.name }}
+                {{ contact.fullName|default(contact.name) }}
                 (
                 {% for email in contact.contactDetails.emails %}
                     <a href="mailto:{{ email.email }}">{{ email.email }}</a>

--- a/reference/content-types/contact_selection.rst
+++ b/reference/content-types/contact_selection.rst
@@ -40,11 +40,20 @@ Example
 
 .. code-block:: xml
 
-    <property name="contact" type="contact_selection">
+    <property name="contacts" type="contact_selection">
         <meta>
             <title lang="en">Contacts</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for contact in content.contacts %}
+        <h3>{{ contact.fullName }}</h3>
+    {% endfor %}
 
 .. _ContactInterface: https://github.com/sulu/sulu/blob/master/src/Sulu/Bundle/ContactBundle/Entity/ContactInterface.php
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/date.rst
+++ b/reference/content-types/date.rst
@@ -21,3 +21,10 @@ Example
             <title lang="en">Date</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.date }}

--- a/reference/content-types/datetime.rst
+++ b/reference/content-types/datetime.rst
@@ -21,3 +21,10 @@ Example
             <title lang="en">Datetime</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.date.format('Y-m-d') }}

--- a/reference/content-types/email.rst
+++ b/reference/content-types/email.rst
@@ -22,3 +22,10 @@ Example
             <title lang="en">E-Mail</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.email }}

--- a/reference/content-types/index.rst
+++ b/reference/content-types/index.rst
@@ -68,6 +68,7 @@ content type:
     page_selection
     phone
     resource_locator
+    route
     select
     single_select
     single_page_selection

--- a/reference/content-types/location.rst
+++ b/reference/content-types/location.rst
@@ -23,3 +23,16 @@ Example
             <title lang="en">Location</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.location.latitude }} <br>
+    {{ content.location.longitude }} <br>
+    {{ content.location.street }} <br>
+    {{ content.location.streetNumber }} <br>
+    {{ content.location.zip }} <br>
+    {{ content.location.city }} <br>
+    {{ content.location.country }}

--- a/reference/content-types/media_selection.rst
+++ b/reference/content-types/media_selection.rst
@@ -66,8 +66,8 @@ Twig
         <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
     {% endfor %}
 
-If you have ``displayOptions`` defined you can access the set ``displayOption``
-over ``view.<property_name>.displayOptions``:
+If your property defines ``displayOptions`, you can access the selected ``displayOption``
+via ``view.<property_name>.displayOptions``:
 
 .. code-block:: twig
 
@@ -77,8 +77,8 @@ over ``view.<property_name>.displayOptions``:
         {% endfor %}
     </div>
 
-If you want to link to documents for download you can do that over the ``.url`` attribute
-alternative you can wrap it with the <sulu_get_media_url>:doc:`../twig-extensions/functions/sulu_get_media_url`
+If you want to provide a link for downloading a document, you can use ``.url`` attribute
+or wrap it with the <sulu_get_media_url>:doc:`../twig-extensions/functions/sulu_get_media_url`
 to control which `disposition header`_ the target url should use:
 
 .. code-block:: twig

--- a/reference/content-types/media_selection.rst
+++ b/reference/content-types/media_selection.rst
@@ -52,6 +52,51 @@ Example
                 <param name="bottom" value="true"/>
                 <param name="rightBottom" value="true"/>
             </param>
+
             <param name="defaultDisplayOption" value="left"/>
         </params>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for image in content.images %}
+        <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
+    {% endfor %}
+
+If you have ``displayOptions`` defined you can access the set ``displayOption``
+over ``view.<property_name>.displayOptions``:
+
+.. code-block:: twig
+
+    <div class="position-{{ view.images.displayOption }}">
+        {% for image in content.images %}
+            <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
+        {% endfor %}
+    </div>
+
+If you want to link to documents for download you can do that over the ``.url`` attribute
+alternative you can wrap it with the <sulu_get_media_url>:doc:`../twig-extensions/functions/sulu_get_media_url`
+to control which `disposition header`_ the target url should use:
+
+.. code-block:: twig
+
+    <ul>
+        {% for document in content.documents %}
+            <li>
+                <a href="{{ document.url }}>
+                    {{ document.title }}
+                </a>
+            </li>
+        {% endfor %}
+    </ul>
+
+.. note::
+
+    For performance reasons you should never use the ``.url`` attribute to render ``images`` on your
+    website. Always use ``thumbnails`` and <configure your image formats>:doc:`../../../book/image-formats`
+    to provide fast optimized cacheable images.
+
+.. _`disposition header`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

--- a/reference/content-types/number.rst
+++ b/reference/content-types/number.rst
@@ -30,13 +30,21 @@ Example
 
 .. code-block:: xml
 
-    <property name="title" type="number">
+    <property name="number" type="number">
         <meta>
             <title lang="en">Number</title>
         </meta>
+
         <params>
             <param name="min" value="0"/>
             <param name="max" value="100"/>
             <param name="step" value="2"/>
         </params>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.number }}

--- a/reference/content-types/page_selection.rst
+++ b/reference/content-types/page_selection.rst
@@ -50,8 +50,25 @@ Example
             <param name="properties" type="collection">
                 <param name="title" value="title"/>
                 <param name="article" value="article"/>
+                <param name="excerptTitle" value="excerpt.title"/>
+                <param name="excerptDescription" value="excerpt.description"/>
             </param>
         </params>
     </property>
 
 .. _jexl: https://github.com/TomFrost/jexl
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for page in content.pages %}
+        <a href="{{ sulu_content_path(page.url) }}">
+            <h3>
+                {{ page.excerptTitle|default(page.title) }}
+            </h3>
+
+            {{ page.excerptDescription|default(page.article) }}
+        </a>
+    {% endfor %}

--- a/reference/content-types/phone.rst
+++ b/reference/content-types/phone.rst
@@ -21,3 +21,10 @@ Example
             <title lang="en">Phone number</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.phone }}

--- a/reference/content-types/resource_locator.rst
+++ b/reference/content-types/resource_locator.rst
@@ -37,13 +37,25 @@ Example
     <property name="title" type="text_line">
         <tag name="sulu.rlp.part"/>
     </property>
+
     <property name="subtitle" type="text_line">
         <tag name="sulu.rlp.part"/>
     </property>
-    <property name="resource_locator" type="resource_locator">
+
+    <property name="url" type="resource_locator">
         <meta>
             <title lang="en">Resource locator</title>
         </meta>
 
         <tag name="sulu.rlp"/>
     </property>
+
+Twig
+----
+
+You need to use the :doc:`../twig-extensions/functions/sulu_content_path` twig extension
+to render the full url.
+
+.. code-block:: twig
+
+    {{ sulu_content_path(content.url) }}

--- a/reference/content-types/route.rst
+++ b/reference/content-types/route.rst
@@ -4,12 +4,12 @@ Route
 Description
 -----------
 
-The ``route`` content type is a content type for generate urls for custom ``entities``.
-Have a look at :doc:`/bundles/route/index` to see how you can add routing to your custom entity.
+The ``route`` content type allows to generate urls for **custom entities**.
+Have a look at :doc:`/bundles/route/index` to see how to implement routing for your custom entity.
 
 .. note::
 
-    The ``route`` content type should not be used for pages, instead use the :doc:`resource_locator`
+    The ``route`` content type should not be used on page templates. For pages, use the :doc:`resource_locator`
     content type instead.
 
 Example

--- a/reference/content-types/route.rst
+++ b/reference/content-types/route.rst
@@ -1,0 +1,44 @@
+Route
+=====
+
+Description
+-----------
+
+The ``route`` content type is a content type for generate urls for custom ``entities``.
+Have a look at :doc:`/bundles/route/index` to see how you can add routing to your custom entity.
+
+.. note::
+
+    The ``route`` content type should not be used for pages, instead use the :doc:`resource_locator`
+    content type instead.
+
+Example
+-------
+
+.. code-block:: xml
+
+    <property name="title" type="text_line">
+        <tag name="sulu.rlp.part"/>
+    </property>
+
+    <property name="subtitle" type="text_line">
+        <tag name="sulu.rlp.part"/>
+    </property>
+
+    <property name="routePath" type="route">
+        <meta>
+            <title lang="en">Resource locator</title>
+        </meta>
+
+        <tag name="sulu.rlp"/>
+    </property>
+
+Twig
+----
+
+You need to use the :doc:`../twig-extensions/functions/sulu_content_path` twig extension
+to render the full url.
+
+.. code-block:: twig
+
+    {{ sulu_content_path(content.routePath) }}

--- a/reference/content-types/select.rst
+++ b/reference/content-types/select.rst
@@ -80,3 +80,14 @@ You can use symfony expression language to access values or set a default value 
             <param name="values" type="expression" value="service('your_service').getValues()"/>
         </params>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for item in content.list %}
+        <span class="icon-{{ item }}>
+            Icon {{ item }}
+        </span>
+    {% endfor %}

--- a/reference/content-types/single_account_selection.rst
+++ b/reference/content-types/single_account_selection.rst
@@ -39,6 +39,12 @@ Example
         </meta>
     </property>
 
+Twig
+----
+
+You need to use the :doc:`../twig-extensions/functions/sulu_resolve_media` if you want to render
+the account logo image.
+
 .. code-block:: twig
 
     {% set account = content.account %}

--- a/reference/content-types/single_contact_selection.rst
+++ b/reference/content-types/single_contact_selection.rst
@@ -39,6 +39,12 @@ Example
         </meta>
     </property>
 
+Twig
+----
+
+You need to use the :doc:`../twig-extensions/functions/sulu_resolve_media` if you want to render
+the contact avatar image.
+
 .. code-block:: twig
 
     {% set contact = content.contact %}

--- a/reference/content-types/single_media_selection.rst
+++ b/reference/content-types/single_media_selection.rst
@@ -74,4 +74,40 @@ Extended Example
         </params>
     </property>
 
+Twig
+----
+
+.. code-block:: twig
+
+    {% set image = content.image %}
+    <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
+
+If you have ``displayOptions`` defined you can access the set ``displayOption``
+over ``view.<property_name>.displayOptions``:
+
+.. code-block:: twig
+
+    {% set image = content.image %}
+
+    <div class="position-{{ view.image.displayOption }}">
+        <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
+    </div>
+
+If you are linking to a document for download you can do that over the ``.url`` attribute
+alternative you can wrap it with the <sulu_get_media_url>:doc:`../twig-extensions/functions/sulu_get_media_url`
+to control which `disposition header`_ the target url should use:
+
+.. code-block:: twig
+
+    <a href="{{ sulu_get_media_url(document.url, 'inline') }}>
+        {{ document.title }}
+    </a>
+
+.. note::
+
+    For performance reasons you should never use the ``.url`` attribute to render ``images`` on your
+    website. Always use ``thumbnails`` and <configure your image formats>:doc:`../../../book/image-formats`
+    to provide fast optimized cacheable images.
+
 .. _Media: https://github.com/sulu/sulu/blob/master/src/Sulu/Bundle/MediaBundle/Api/Media.php
+.. _`disposition header`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

--- a/reference/content-types/single_media_selection.rst
+++ b/reference/content-types/single_media_selection.rst
@@ -82,8 +82,8 @@ Twig
     {% set image = content.image %}
     <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
 
-If you have ``displayOptions`` defined you can access the set ``displayOption``
-over ``view.<property_name>.displayOptions``:
+If your property defines ``displayOptions`, you can access the selected ``displayOption``
+via ``view.<property_name>.displayOptions``:
 
 .. code-block:: twig
 
@@ -93,8 +93,8 @@ over ``view.<property_name>.displayOptions``:
         <img src="{{ image.thumbnails['400x400'] }}" alt="{{ image.title }}" title="{{ image.description|default(image.title) }}">
     </div>
 
-If you are linking to a document for download you can do that over the ``.url`` attribute
-alternative you can wrap it with the <sulu_get_media_url>:doc:`../twig-extensions/functions/sulu_get_media_url`
+If you want to provide a link for downloading a document, you can use ``.url`` attribute
+or wrap it with the <sulu_get_media_url>:doc:`../twig-extensions/functions/sulu_get_media_url`
 to control which `disposition header`_ the target url should use:
 
 .. code-block:: twig

--- a/reference/content-types/single_page_selection.rst
+++ b/reference/content-types/single_page_selection.rst
@@ -34,8 +34,8 @@ Example
         </meta>
     </property>
 
-Usage
------
+Twig
+----
 
 Currently this content type only returns the UUID of the target page. In
 order to construct a link to the page use:
@@ -46,5 +46,11 @@ order to construct a link to the page use:
 
 Then ``target.content`` will give you access to the URL and other properties
 of the target page.
+
+.. note::
+
+    The ``sulu_content_load`` twig extension loads the whole page with it content and so
+    can have a negative impact on the performance of the page and if possible should be
+    avoided.
 
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/single_page_selection.rst
+++ b/reference/content-types/single_page_selection.rst
@@ -49,8 +49,8 @@ of the target page.
 
 .. note::
 
-    The ``sulu_content_load`` twig extension loads the whole page with it content and so
-    can have a negative impact on the performance of the page and if possible should be
-    avoided.
+    The ``sulu_content_load`` twig extension loads and resolves the whole page content.
+    This is an expensive operation and can have a negative impact on the performance of 
+    the page. If possible, the extension should be avoided.
 
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/single_select.rst
+++ b/reference/content-types/single_select.rst
@@ -71,3 +71,12 @@ You can use symfony expression language to access values or set a default value 
             <param name="values" type="expression" value="service('your_service').getValues()"/>
         </params>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    <span class="icon-{{ content.single }}>
+        Icon {{ content.single }}
+    </span>

--- a/reference/content-types/smart_content.rst
+++ b/reference/content-types/smart_content.rst
@@ -248,7 +248,7 @@ to the content URL. Same takes effect for `?type=image` with the media type
 
 .. _example:
 
-Example for "content" DataProvider
+Example for "pages" DataProvider
 ----------------------------------
 
 Page template
@@ -265,6 +265,7 @@ Page template
             <param name="provider" value="pages"/>
             <param name="max_per_page" value="5"/>
             <param name="page_parameter" value="p"/>
+
             <param name="properties" type="collection">
                 <param name="article" value="article"/>
                 <param name="excerptTitle" value="excerpt.title"/>
@@ -272,12 +273,14 @@ Page template
                 <param name="excerptImages" value="excerpt.images"/>
                 <param name="excerptDescription" value="excerpt.description"/>
             </param>
+
             <param name="present_as" type="collection">
                 <param name="two">
                     <meta>
                         <title lang="en">Two columns</title>
                     </meta>
                 </param>
+
                 <param name="one">
                     <meta>
                         <title lang="en">One column</title>
@@ -298,28 +301,30 @@ Twig template
         {% if page-1 >= 1 %}
             <li><a href="{{ sulu_content_path(content.url) }}?p={{ page-1 }}">&laquo;</a></li>
         {% endif %}
+
         {% if view.pages.hasNextPage %}
             <li><a href="{{ sulu_content_path(content.url) }}?p={{ page+1 }}">&raquo;</a></li>
         {% endif %}
     </ul>
 
     <div property="pages">
-    {% for page in content.pages %}
-        <div class="col-lg-{{ view.pages.presentAs == 'two' ? '6' : '12' }}">
-            <h2>
-                <a href="{{ sulu_content_path(page.url) }}">{{ page.title }}</a>
-            </h2>
-            <p>
-                <i>{{ page.excerptTitle }}</i> | <i>{{ page.excerptTags|join(', ') }}</i>
-            </p>
-            {% if page.excerptImages|length > 0 %}
-                <img src="{{ page.excerptImages[0].thumbnails['50x50'] }}" alt="{{ page.excerptImages[0].title }}"/>
-            {% endif %}
-            {% autoescape false %}
-                {{ page.article }}
-            {% endautoescape %}
-        </div>
-    {% endfor %}
+        {% for page in content.pages %}
+            <div class="col-lg-{{ view.pages.presentAs == 'two' ? '6' : '12' }}">
+                <h2>
+                    <a href="{{ sulu_content_path(page.url) }}">{{ page.title }}</a>
+                </h2>
+
+                <p>
+                    <i>{{ page.excerptTitle }}</i> | <i>{{ page.excerptTags|join(', ') }}</i>
+                </p>
+
+                {% if page.excerptImages|length > 0 %}
+                    <img src="{{ page.excerptImages[0].thumbnails['50x50'] }}" alt="{{ page.excerptImages[0].title }}"/>
+                {% endif %}
+
+                {{ page.article|raw }}
+            </div>
+        {% endfor %}
     </div>
 
 .. note::

--- a/reference/content-types/snippet_selection.rst
+++ b/reference/content-types/snippet_selection.rst
@@ -67,4 +67,13 @@ Example
         </params>
     </property>
 
+Twig
+----
+
+.. code-block:: twig
+
+    {% for snippet in content.snippets %}
+        {{ snippet.title }}
+    {% endfor %}
+
 .. _jexl: https://github.com/TomFrost/jexl

--- a/reference/content-types/tag_selection.rst
+++ b/reference/content-types/tag_selection.rst
@@ -14,8 +14,8 @@ tags will be saved as an array.
 
 .. note::
 
-    Mostly this content type is not needed as all pages can be tagged over
-    the ``Excerpt and Taxonomies`` tab.
+    This content type is rarely needed because the ``Excerpt and Taxonomies``
+    allows to assign tags to pages.
 
 Parameters
 ----------

--- a/reference/content-types/tag_selection.rst
+++ b/reference/content-types/tag_selection.rst
@@ -10,7 +10,12 @@ tags will be saved as an array.
 
 .. note::
 
-    Tags which do not already exist will be created. 
+    Tags which do not already exist will be created.
+
+.. note::
+
+    Mostly this content type is not needed as all pages can be tagged over
+    the ``Excerpt and Taxonomies`` tab.
 
 Parameters
 ----------
@@ -27,3 +32,12 @@ Example
             <title lang="en">Tags</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {% for tag in content.tags %}
+        {{ tag }}
+    {% endfor %}

--- a/reference/content-types/teaser_selection.rst
+++ b/reference/content-types/teaser_selection.rst
@@ -6,7 +6,7 @@ content in your website. These teasers could be arranged as list or grid, like
 in this example:
 
 .. figure:: ../../img/teaser-selection-web.png
-	:align: center
+    :align: center
 
 In the administration interface, the widget is displayed as a selector for the
 teasers. Content managers can choose a number of target contents. By default,
@@ -14,7 +14,7 @@ the text from the "Excerpt & Categories" tab of the target content is shown.
 You can however customize the text of the teaser if you like.
 
 .. figure:: ../../img/teaser-selection-admin.png
-	:align: center
+    :align: center
 
 Configuration
 -------------
@@ -45,13 +45,13 @@ Add a field of type "teaser_selection" to your page template:
         </properties>
     </template>
 
-Rendering
----------
+Twig
+----
 
 In Twig, the field contains an array of teasers. Iterate the array and format
 the teasers as you like:
 
-.. code-block:: html+jinja
+.. code-block:: twig
 
     <div>
         {% for teaser in content.teasers %}
@@ -185,11 +185,11 @@ The content manager can choose one of these variants in the administration
 interface:
 
 .. figure:: ../../img/teaser-selection-menu.png
-	:align: center
+    :align: center
 
 The selected value can be used to set the CSS class of the teaser element in Twig:
 
-.. code-block:: html+jinja
+.. code-block:: twig
 
     <ul property="teasers" class="{{ view.teasers.presentAs|default('') }}">
         {% for teaser in content.teasers %}

--- a/reference/content-types/text_area.rst
+++ b/reference/content-types/text_area.rst
@@ -21,3 +21,10 @@ Example
             <title lang="en">Description</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.description }}

--- a/reference/content-types/text_editor.rst
+++ b/reference/content-types/text_editor.rst
@@ -17,8 +17,8 @@ Example
             <title lang="en">Description</title>
         </meta>
     </property>
-    
-Usage
+
+Twig
 -----
 
 When outputting the text editor field in twig the `raw filter`_ need to be used:
@@ -26,5 +26,5 @@ When outputting the text editor field in twig the `raw filter`_ need to be used:
 .. code-block:: twig
 
     {{ content.description|raw }}
-    
-.. _raw filter: https://twig.symfony.com/doc/2.x/filters/raw.html
+
+.. _raw filter: https://twig.symfony.com/doc/3.x/filters/raw.html

--- a/reference/content-types/text_line.rst
+++ b/reference/content-types/text_line.rst
@@ -32,3 +32,10 @@ Example
             <param name="headline" value="true"/>
         </params>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.title }}

--- a/reference/content-types/time.rst
+++ b/reference/content-types/time.rst
@@ -22,3 +22,10 @@ Example
             <title lang="en">Time</title>
         </meta>
     </property>
+
+Twig
+----
+
+.. code-block:: twig
+
+    {{ content.time }}

--- a/reference/content-types/url.rst
+++ b/reference/content-types/url.rst
@@ -61,7 +61,7 @@ Extended Example
 Twig
 ----
 
-The content type return the full url which can directly be rendered:
+The content type returns the full url which can be rendered directly:
 
 .. code-block:: twig
 

--- a/reference/content-types/url.rst
+++ b/reference/content-types/url.rst
@@ -50,9 +50,21 @@ Extended Example
                 <param name="scheme" value="http://"/>
                 <param name="specific_part" value="www.google.at"/>
             </param>
+
             <param name="schemes" type="collection">
                 <param name="http://"/>
                 <param name="https://"/>
             </param>
         </params>
     </property>
+
+Twig
+----
+
+The content type return the full url which can directly be rendered:
+
+.. code-block:: twig
+
+    <a href="{{ content.url }}">
+        {{ content.url }}
+    </a>

--- a/reference/twig-extensions/functions/sulu_content_load.rst
+++ b/reference/twig-extensions/functions/sulu_content_load.rst
@@ -18,6 +18,6 @@ Returns a Structure for the given UUID
 
 .. note::
 
-    The ``sulu_content_load`` twig extension loads the whole page with it content and so
-    can have a negative impact on the performance of the page and if possible should be
-    avoided.
+    The ``sulu_content_load`` twig extension loads and resolves the whole page content.
+    This is an expensive operation and can have a negative impact on the performance of 
+    the page. If possible, the extension should be avoided.

--- a/reference/twig-extensions/functions/sulu_content_load.rst
+++ b/reference/twig-extensions/functions/sulu_content_load.rst
@@ -14,3 +14,10 @@ Returns a Structure for the given UUID
 **Returns**:
 
 .. include:: _page_structure.inc
+
+
+.. note::
+
+    The ``sulu_content_load`` twig extension loads the whole page with it content and so
+    can have a negative impact on the performance of the page and if possible should be
+    avoided.

--- a/reference/twig-extensions/functions/sulu_content_load_parent.rst
+++ b/reference/twig-extensions/functions/sulu_content_load_parent.rst
@@ -14,3 +14,9 @@ Return the parent of the Structure with the given UUID
 **Returns**:
 
 .. include:: _page_structure.inc
+
+.. note::
+
+    The ``sulu_content_load_parent`` twig extension loads the whole page with it content and so
+    can have a negative impact on the performance of the page and if possible should be
+    avoided.

--- a/reference/twig-extensions/functions/sulu_content_load_parent.rst
+++ b/reference/twig-extensions/functions/sulu_content_load_parent.rst
@@ -17,6 +17,6 @@ Return the parent of the Structure with the given UUID
 
 .. note::
 
-    The ``sulu_content_load_parent`` twig extension loads the whole page with it content and so
-    can have a negative impact on the performance of the page and if possible should be
-    avoided.
+    The ``sulu_content_load_parent`` twig extension loads and resolves the whole page content.
+    This is an expensive operation and can have a negative impact on the performance of 
+    the page. If possible, the extension should be avoided.

--- a/reference/twig-extensions/functions/sulu_content_path.rst
+++ b/reference/twig-extensions/functions/sulu_content_path.rst
@@ -29,9 +29,3 @@ prioritize one by giving it ``<url main="true">``.
   used to generate the url (**optional**)
 
 **Returns**: *string* - Absolute URL
-
-.. note::
-
-    The ``sulu_content_load`` twig extension loads the whole page with it content and so
-    can have a negative impact on the performance of the page and if possible should be
-    avoided.

--- a/reference/twig-extensions/functions/sulu_content_path.rst
+++ b/reference/twig-extensions/functions/sulu_content_path.rst
@@ -1,7 +1,7 @@
 ``sulu_content_path``
 =====================
 
-Returns the absolute URL for the content at the given path. The domain 
+Returns the absolute URL for the content at the given path. The domain
 is taken from ``config/webspaces/*.xml`` and your current
 environment. In case you have multiple URLs in one environment, you can
 prioritize one by giving it ``<url main="true">``.
@@ -29,3 +29,9 @@ prioritize one by giving it ``<url main="true">``.
   used to generate the url (**optional**)
 
 **Returns**: *string* - Absolute URL
+
+.. note::
+
+    The ``sulu_content_load`` twig extension loads the whole page with it content and so
+    can have a negative impact on the performance of the page and if possible should be
+    avoided.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes -
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Add twig example to every content type.

#### Why?

How the content type can be used in twig is I think very important and will help a lot of developers.
