### PR TITLE
Add @RouteResource annotation in Extend Admin UI example

### DIFF
--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -211,7 +211,7 @@ shows a controller doing what has just been described.
     use Symfony\Component\HttpFoundation\Response;
 
     /**
-     * @RouteResource("Event")
+     * @RouteResource(Event::RESOURCE_KEY)
      */
     class EventController implements ClassResourceInterface
     {

--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -211,7 +211,7 @@ shows a controller doing what has just been described.
     use Symfony\Component\HttpFoundation\Response;
 
     /**
-     * @RouteResource(Event::RESOURCE_KEY)
+     * @RouteResource("event")
      */
     class EventController implements ClassResourceInterface
     {

--- a/book/extend-admin.rst
+++ b/book/extend-admin.rst
@@ -200,6 +200,7 @@ shows a controller doing what has just been described.
     namespace App\Controller\Admin;
 
     use App\Entity\Event;
+    use FOS\RestBundle\Controller\Annotations\RouteResource;
     use FOS\RestBundle\Routing\ClassResourceInterface;
     use FOS\RestBundle\View\View;
     use FOS\RestBundle\View\ViewHandlerInterface;
@@ -209,6 +210,9 @@ shows a controller doing what has just been described.
     use Sulu\Component\Rest\RestHelperInterface;
     use Symfony\Component\HttpFoundation\Response;
 
+    /**
+     * @RouteResource("Event")
+     */
     class EventController implements ClassResourceInterface
     {
         /**


### PR DESCRIPTION
| Q | A
| --- | ---
| License | MIT

#### Why?

When using an entity name that consists of two words (eg. `EventRegistration`), the `FOSRestBundle` will position the `id` parameter in the path between the `event` and `registration`: `/admin/api/events/{id}/registrations.{_format} `

This is not compatible with the Sulu UI. The Sulu UI expects the `id` parameter at the end of the path, because it needs to be omitted for the `POST` request when creating a new entity.
