### PR TITLE
Add warning for override entities to set table to the correct name

### DIFF
--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -16,7 +16,7 @@ You can extend all of them in the same way. Therefor we explain it for `User` he
 Create a Entity
 ---------------
 
-Create your own Entity for example in the `ClientWebsiteBundle`. You can use the 
+Create your own Entity for example in the `ClientWebsiteBundle`. You can use the
 `doctrine:generate:entity` command for that. Extend the generated Entity with the
 Sulu `User` class.
 
@@ -30,7 +30,7 @@ Sulu `User` class.
     use Sulu\Bundle\SecurityBundle\Entity\User as SuluUser;
 
     /**
-     * User
+     * Following annotations are required and should not be changed:
      *
      * @ORM\Table(name="se_users")
      * @ORM\Entity
@@ -60,7 +60,7 @@ Sulu `User` class.
         /**
          * Get myProperty
          *
-         * @return string 
+         * @return string
          */
         public function getMyProperty()
         {
@@ -71,14 +71,19 @@ Sulu `User` class.
 .. warning::
 
     Your Entity can have own properties, but they should have at least default values.
-    Otherwise the normal features of Sulu could crash (like the 
+    Otherwise the normal features of Sulu could crash (like the
     `sulu:security:user:create` command).
+
+    The `@ORM\\Table` annotation need to match the exist table else you will get strange
+    errors when query data from it.
 
 Configuration
 -------------
 
-You can specify your new Entity and if it exists your Repository in the `sulu_security` 
+You can specify your new Entity and if it exists your Repository in the `sulu_security`
 configuration section in the file app/config/config.yml.
+
+For the `User` entity (`se_users`):
 
 .. code-block:: yaml
 
@@ -88,7 +93,7 @@ configuration section in the file app/config/config.yml.
                 model: Client\Bundle\WebsiteBundle\Entity\User
                 repository: Sulu\Bundle\SecurityBundle\Entity\UserRepository
 
-For the `Role` entity:
+For the `Role` entity (`se_roles`):
 
 .. code-block:: yaml
 
@@ -98,7 +103,7 @@ For the `Role` entity:
                 model:                Sulu\Bundle\SecurityBundle\Entity\Role
                 repository:           Sulu\Bundle\SecurityBundle\Entity\RoleRepository
 
-For the `Contact` entity:
+For the `Contact` entity (`co_contacts`):
 
 .. code-block:: yaml
 
@@ -108,7 +113,7 @@ For the `Contact` entity:
                 model:                Sulu\Bundle\ContactBundle\Entity\Contact
                 repository:           Sulu\Bundle\ContactBundle\Entity\ContactRepository
 
-For the `Media` entity:
+For the `Media` entity (`me_media`):
 
 .. code-block:: yaml
 
@@ -120,5 +125,4 @@ For the `Media` entity:
 
 .. warning::
 
-    If you override the entities you lose your old tables and data. You should provide
-    a upgrade script.
+    If you override the entities you should provide a data migration script to avoid data lose.

--- a/cookbook/extend-entities.rst
+++ b/cookbook/extend-entities.rst
@@ -30,7 +30,7 @@ Sulu `User` class.
     use Sulu\Bundle\SecurityBundle\Entity\User as SuluUser;
 
     /**
-     * Following annotations are required and should not be changed:
+     * The following annotations are required for replacing the table of the extended entity:
      *
      * @ORM\Table(name="se_users")
      * @ORM\Entity
@@ -74,8 +74,10 @@ Sulu `User` class.
     Otherwise the normal features of Sulu could crash (like the
     `sulu:security:user:create` command).
 
-    The `@ORM\\Table` annotation need to match the exist table else you will get strange
-    errors when query data from it.
+.. warning::
+
+    The `@ORM\\Table` annotation on your entity must match the table of the extended entity. 
+    Otherwise, doctrine might run into errors when querying data of the entity.
 
 Configuration
 -------------
@@ -125,4 +127,4 @@ For the `Media` entity (`me_media`):
 
 .. warning::
 
-    If you override the entities you should provide a data migration script to avoid data lose.
+    If you override entities in an existing project, you need to migrate the existing data to avoid data loss.


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Add warning for override entities.

#### Why?

The table need to match the table from the overridden entity.
