### PR TITLE
Add jackalope.jackrabbit_version parameter to jackrabbit cookbook

### DIFF
--- a/cookbook/jackrabbit.rst
+++ b/cookbook/jackrabbit.rst
@@ -37,6 +37,8 @@ can e.g. be set in your ``.env`` file.
                 backend:
                     type: jackrabbit
                     url: "%env(JACKRABBIT_URL)%"
+                    parameters:
+                        "jackalope.jackrabbit_version": "%env(JACKRABBIT_VERSION)%"
                 workspace: "%env(PHPCR_WORKSPACE)%"
                 username: "%env(PHPCR_USER)%"
                 password: "%env(PHPCR_PASSWORD)%"
@@ -44,6 +46,8 @@ can e.g. be set in your ``.env`` file.
                 backend:
                     type: jackrabbit
                     url: "%env(JACKRABBIT_URL)%"
+                    parameters:
+                        "jackalope.jackrabbit_version": "%env(JACKRABBIT_VERSION)%"
                 workspace: "%env(PHPCR_WORKSPACE)%_live"
                 username: "%env(PHPCR_USER)%"
                 password: "%env(PHPCR_PASSWORD)%"


### PR DESCRIPTION
The `jackalope.jackrabbit_version` parameter was implemented in https://github.com/jackalope/jackalope-jackrabbit/pull/164 to enable full UTF-8 support. For example, this allows to store emojis such as 🤯  or 🐣.