### PR TITLE
Remove display_options param from smart_content documentation

### DIFF
--- a/reference/content-types/smart_content.rst
+++ b/reference/content-types/smart_content.rst
@@ -68,10 +68,6 @@ Parameters
     * - category_root
       - string
       - Root category (key) to display category-tree.
-    * - display_options
-      - collection
-      - Hide form-elements (tags, categories, sorting, limit, presentAs)
-        can hide available elements for DataProvider.
     * - exclude_duplicates
       - bool
       - If the provider is able to detect duplicates the content-type filters


### PR DESCRIPTION
It looks like this param is not handled in the frontend at all when using Sulu 2 😕 