### PR TITLE
Add missing documentation for max_characters, max_segments and segment_delimiter params

### DIFF
--- a/reference/content-types/text_area.rst
+++ b/reference/content-types/text_area.rst
@@ -9,7 +9,15 @@ Shows a simple text area, the inserted content will be saved as simple string.
 Parameters
 ----------
 
-No parameters available
+.. list-table::
+    :header-rows: 1
+
+    * - Parameter
+      - Type
+      - Description
+    * - max_characters
+      - string
+      - Soft limit for maximum number of characters. Will show a character counter.
 
 Example
 -------

--- a/reference/content-types/text_line.rst
+++ b/reference/content-types/text_line.rst
@@ -18,6 +18,15 @@ Parameters
     * - headline
       - boolean
       - If true the height and font size of the text line get increased.
+    * - max_characters
+      - string
+      - Soft limit for maximum number of characters. Will show a character counter.
+    * - max_segments
+      - string
+      - Soft limit for maximum number of segments. Will show a segment counter.
+    * - segment_delimiter
+      - string
+      - The delimiter used to split the value into segments (required to use `max_segments`)
 
 Example
 -------


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #issuenum
| Related PRs | sulu/sulu#prnum
| License | MIT

#### What's in this PR?

Add missing documentation for `max_characters`, `max_segments` and `segment_delimiter` params for `text_line` and `text_area` content types

#### Why?

Because it's missing in the docs
