### PR TITLE
Emphasize the possibility of using nested blocks since Sulu 2.1

### DIFF
--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -35,8 +35,8 @@ used by default.
 
 The other essential attribute is the ``types``-tag, which contains multiple
 ``type``-tags. A type defines some titles and its containing ``properties``,
-whereby all the available :doc:`index` (except the block itself, since we do
-not support nesting) can be used. These types are offered to the content
+whereby all the available :doc:`index` (including the block itself, since we do
+support nesting since 2.1) can be used. These types are offered to the content
 manager via dropdown.
 
 If collapsed the system will show the content of three properties in the block

--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -35,8 +35,7 @@ used by default.
 
 The other essential attribute is the ``types``-tag, which contains multiple
 ``type``-tags. A type defines some titles and its containing ``properties``,
-whereby all the available :doc:`index` (including the block itself, since we do
-support nesting since 2.1) can be used. These types are offered to the content
+whereby all the available :doc:`index` can be used. These types are offered to the content
 manager via dropdown.
 
 If collapsed the system will show the content of three properties in the block

--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -35,8 +35,8 @@ used by default.
 
 The other essential attribute is the ``types``-tag, which contains multiple
 ``type``-tags. A type defines some titles and its containing ``properties``,
-whereby all the available :doc:`index` can be used. These types are offered to the content
-manager via dropdown.
+whereby all the available :doc:`index` can be used. These types are offered 
+to the content manager via dropdown.
 
 If collapsed the system will show the content of three properties in the block
 by default, in order to give the content manager an idea which block they are


### PR DESCRIPTION
| Q | A
| License | MIT

What's in this PR?
Updating the documentation about the possibility using nested blocks

Why?
Related to https://sulu.io/blog/sulu-2-1-rc1-is-here-with-symfony-5-support-nested-blocks-and-deep-links and related to my own tests sulu supports nesting starting with version 2.1.