### PR TITLE
Document how to render blocks in Twig

### DIFF
--- a/book/twig.rst
+++ b/book/twig.rst
@@ -186,6 +186,25 @@ this code:
 
 Image formats need to be defined in the `image_formats.xml`_ in your config.
 
+Blocks
+^^^^^^
+
+The block is one of the most important content types in Sulu. It gives the content manager the
+possibility to add different sections and components to a page, which they can place in any order
+they want.
+
+In Twig it is recommended to use the following snippet to render the blocks. This way you have
+access to the ``content`` and ``view`` variables of each block again.
+
+.. code-block:: twig
+
+    {% for block in content.blocks %}
+        {% include 'includes/blocks/' ~ block.type ~ '.html.twig' with {
+            content: block,
+            view: view.blocks[loop.index0],
+        } %}
+    {% endfor %}
+
 CSS / JS
 --------
 

--- a/book/twig.rst
+++ b/book/twig.rst
@@ -189,9 +189,9 @@ Image formats need to be defined in the `image_formats.xml`_ in your config.
 Blocks
 ^^^^^^
 
-The block is one of the most important content types in Sulu. It gives the content manager the
-possibility to add different sections and components to a page, which they can place in any order
-they want.
+The block content type is one of the most important content types in Sulu. It allows content managers to add
+different sections and components to a page,
+which they can place in any order they want.
 
 In Twig it is recommended to use the following snippet to render the blocks. This way you have
 access to the ``content`` and ``view`` variables of each block again.

--- a/reference/content-types/block.rst
+++ b/reference/content-types/block.rst
@@ -218,6 +218,9 @@ The value of your field can be accessed in twig over the ``settings`` variable:
 
     {% for block in content.blocks %}
         <div class="blocks__item{% if block.settings.theme|default %} block__item--{{ block.settings.theme }}{% endif %}">
-            {# ... #}
+            {% include 'includes/blocks/' ~ block.type ~ '.html.twig' with {
+                content: block,
+                view: view.blocks[loop.index0],
+            } %}
         </div>
     {% endfor %}


### PR DESCRIPTION
Adds a **Blocks** section to the Twig chapter which shows the recommended way to render
blocks via an include per block type, so that `content` and `view` are available inside
each block template.

The example in the block content type reference was extended in the same way, replacing
the `{# ... #}` placeholder with the actual include.