### PR TITLE
Explain the difference between system languages and content languages

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -28,28 +28,58 @@ This command will bootstrap a new project in the directory ``my-project``.
         git add .
         git commit -m "Initial commit"
 
+.. _getting-started-system-languages:
+
+System Languages vs Content Languages
+-------------------------------------
+
+Sulu distinguishes two kinds of languages, which are configured in different
+places and should not be confused:
+
+* The **system languages** are the languages of the administration interface.
+  Every user picks one of them in their profile, and it defines the language of
+  the menus, the buttons, the error messages and the labels of your templates
+  (the ``<title lang="...">`` elements of the template XML files, see
+  :doc:`templates`).
+* The **content languages** (called *localizations* in Sulu) are the languages
+  in which your content is written and published. They are configured per
+  webspace (see the next section and :doc:`localization`), and a content
+  editor switches between them while editing a page.
+
+The two lists are independent: a german speaking editor can manage content
+written in french, and a website can be published in languages that nobody
+uses in the administration interface.
+
+The system languages are configured in the ``sulu_core`` section. By default,
+Sulu ships with english and german:
+
+.. code-block:: yaml
+
+    # config/packages/sulu_admin.yaml
+    sulu_core:
+        locales:
+            en: English
+            de: Deutsch
+        translations:
+            - en
+            - de
+
+The ``locales`` key lists the languages a user can select in their profile,
+with the label displayed in the dropdown, and ``translations`` lists the
+translations of the administration interface to download. Available languages
+are shown on `Crowdin`_. After adding a language, download its translations by
+running the following command:
+
+.. code-block:: bash
+
+    php bin/console sulu:admin:download-language
+
 .. note::
 
-    If you want to use other languages than english or german for the
-    administration interface of Sulu you need to configure them in the
-    ``config/packages/sulu_admin.yaml`` file:
-
-    .. code-block:: yaml
-
-        sulu_core:
-            locales:
-                en: English
-                de: Deutsch
-            translations:
-                - en
-                - de
-
-    Available languages are shown on `Crowdin`_.
-    Afterwards the languages have to be downloaded by running the following command:
-
-    .. code-block:: bash
-
-        php bin/console sulu:admin:download-language
+    Template labels are not part of the Crowdin translations: when you add a
+    system language, you also have to provide the ``<title>`` of your templates
+    and properties in that language, otherwise the labels fall back to the
+    ``fallback_locale`` of the ``sulu_core`` section (``en`` by default).
 
 Webspaces
 ---------

--- a/book/localization.rst
+++ b/book/localization.rst
@@ -7,6 +7,12 @@ using Sulu. Sulu also considers the different variations of a language among
 different countries. The combination of these two factors is called a
 localization.
 
+.. note::
+
+    Localizations are the languages of your *content*. They are independent of
+    the :ref:`system languages <getting-started-system-languages>`, which are
+    the languages of the administration interface itself.
+
 Configuring webspace localizations
 ----------------------------------
 

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -66,6 +66,15 @@ the XML:
 
 You can customize the text by changing this property.
 
+.. note::
+
+    The ``lang`` attribute of the ``<title>`` elements refers to a
+    :ref:`system language <getting-started-system-languages>`, which is the
+    language of the administration interface selected by the user, and not to
+    one of the content languages of your webspaces. Add a ``<title>`` for each
+    language configured in ``sulu_core.translations``; the ``fallback_locale``
+    of that section is used when a language is missing.
+
 Creating a Custom Template
 --------------------------
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #924
| Related PRs | -
| License | MIT

#### What's in this PR?

- `book/getting-started.rst`: the note about `sulu_core.locales` becomes a "System Languages vs Content Languages" section (with a `getting-started-system-languages` anchor) explaining what the system languages are (the language of the administration interface, picked per user, which also drives the template labels), how they differ from the content localizations configured per webspace, what the `locales` and `translations` keys do, and that template `<title>` labels are not covered by the Crowdin translations (they fall back to `sulu_core.fallback_locale`).
- `book/templates.rst`: a note next to the `<meta><title lang="en">` example stating that `lang` is a system language, not a content locale, and that a title should exist for every language of `sulu_core.translations`.
- `book/localization.rst`: a short note pointing out that localizations are the content languages, with a link back to the new section.

Targets `3.x` since the issue refers to the 3.x pages; happy to open a backport to `2.x` if wanted. Sphinx builds without warnings on the three files.

#### Why?

The getting started guide showed how to add system languages without saying what they are, and the templates documentation never said that the `lang` attribute of the labels is a system language rather than a content language, which is an easy thing to get wrong (see #924).
