### PR TITLE
Add a CI check for renamed or removed pages and the missing redirects

### DIFF
--- a/.github/check-redirects.py
+++ b/.github/check-redirects.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Fail when a renamed or removed page has no entry in the ``redirects`` map of conf.py.
+
+Expects the output of ``git diff --name-status --diff-filter=DR -- '*.rst'`` as first argument:
+one line per file, ``D<TAB>path`` for a removal, ``R<score><TAB>old<TAB>new`` for a rename.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+changes = Path(sys.argv[1]).read_text().splitlines()
+conf = Path(__file__).resolve().parent.parent.joinpath("conf.py").read_text()
+redirected = set(re.findall(r'^\s*"([^"]+)"\s*:', conf, flags=re.MULTILINE))
+
+missing = []
+for line in changes:
+    parts = line.split("\t")
+    if len(parts) < 2:
+        continue
+    old = parts[1]
+    if not old.endswith(".rst") or old.endswith(".rst.inc"):
+        continue
+    docname = old[: -len(".rst")]
+    if docname not in redirected:
+        target = parts[2][: -len(".rst")] if len(parts) > 2 else "<new location>"
+        missing.append((docname, target))
+
+if not missing:
+    print("Every renamed or removed page has a redirect.")
+    sys.exit(0)
+
+print("The following pages were renamed or removed without a redirect in conf.py.")
+print("Add an entry to the `redirects` map, the target being relative to the old page, e.g.:\n")
+for docname, target in missing:
+    depth = docname.count("/")
+    print(f'    "{docname}": "{"../" * depth}{target}.html",')
+sys.exit(1)

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -27,3 +27,17 @@ jobs:
               with:
                   name: DocumentationHTML
                   path: "_build/html"
+
+    redirects:
+        name: "Check redirects of renamed or removed pages"
+        runs-on: ubuntu-latest
+        if: github.event_name == 'pull_request'
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+
+            - name: Check that every renamed or removed page has a redirect in conf.py
+              run: |
+                  git diff --name-status --diff-filter=DR "origin/${{ github.base_ref }}...HEAD" -- '*.rst' > changes.txt
+                  python3 .github/check-redirects.py changes.txt

--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ To remove all built files:
 
 
 [1]: https://www.sphinx-doc.org/en/master/usage/installation.html
+
+## Renaming or removing a page
+
+The documentation is published for several versions (`2.x`, `3.x`, ...) and the version switcher keeps the current
+path, so a page that is renamed or removed in one version must keep answering at its old URL. Add an entry to the
+`redirects` map of `conf.py` (handled by [sphinx-reredirects](https://pypi.org/project/sphinx-reredirects/)), with the
+target relative to the old page:
+
+```python
+redirects = {
+    "reference/content-types/text_line": "../../reference/property-types/text_line.html",
+}
+```
+
+A check in the CI fails when a pull request renames or removes an `.rst` file without such an entry.

--- a/conf.py
+++ b/conf.py
@@ -42,6 +42,7 @@ extensions = [
 
 # Redirects for version switcher (property-types -> content-types for 1.0/2.x)
 redirects = {
+    "bundles/reference-store": "../bundles/website/reference-store.html",
     "reference/property-types/index": "../../reference/content-types/index.html",
     "reference/property-types/account_selection": "../../reference/content-types/account_selection.html",
     "reference/property-types/block": "../../reference/content-types/block.html",
@@ -78,6 +79,7 @@ redirects = {
     "reference/property-types/tag_selection": "../../reference/content-types/tag_selection.html",
     "reference/property-types/teaser_selection": "../../reference/content-types/teaser_selection.html",
     "reference/property-types/text_area": "../../reference/content-types/text_area.html",
+    "reference/property-types/text_editor": "../../reference/content-types/text_editor.html",
     "reference/property-types/text_line": "../../reference/content-types/text_line.html",
     "reference/property-types/time": "../../reference/content-types/time.html",
     "reference/property-types/url": "../../reference/content-types/url.html",


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #856
| Related PRs | #935, #855, #874
| License | MIT

#### What's in this PR?

- A `redirects` job in the "Build docs" workflow, running on pull requests: `.github/check-redirects.py` lists the `.rst` files renamed or removed by the PR (`git diff --name-status --diff-filter=DR` against the base branch) and fails when one of them has no entry in the `redirects` map of `conf.py`, printing the entry to add (target relative to the old page).
- A "Renaming or removing a page" section in the README explaining the mechanism.
- `conf.py`: the two entries missing on the `1.x` / `2.x` side of the mirror maps (the version switcher keeps the path): `reference/property-types/text_editor` (the only page of the #855 rename left out of #874) and `bundles/reference-store`, which is `bundles/website/reference-store` here.

Targets `1.x` so that everything merges up; the two `3.x`-only entries of the map are in #935, since they cannot come through the merge.

Checked locally on `1.x`: `sphinx-build -n -W` passes and the two redirect pages are generated with the right targets; the check script was exercised with a passing and a failing change list.
