### PR TITLE
Split the webspace documentation into getting started, navigation and reference pages

### DIFF
--- a/book/getting-started.rst
+++ b/book/getting-started.rst
@@ -85,7 +85,8 @@ administration interface. The key is the unique identifier of the webspace:
     recommend to decide what key to use before you build the database in the
     next step.
 
-We'll :doc:`return to webspaces <webspaces>` later in this book.
+We'll :doc:`return to webspaces <webspaces>` later in this book, to configure
+the localizations, templates, navigation and URLs of your website.
 
 Setup the Database
 ------------------

--- a/book/index.rst
+++ b/book/index.rst
@@ -16,6 +16,7 @@ Be sure to know a thing or two about `Symfony`_. Sulu is based on Symfony and st
     twig
     content-architecture
     webspaces
+    navigation
     image-formats
     localization
     smart-content

--- a/book/localization.rst
+++ b/book/localization.rst
@@ -53,8 +53,8 @@ new localization, so make sure to assign them in the contact permissions tab.
     When adding a new localization you have to make sure that the localization
     is also covered by one of the webspaces URLs. This can either happen by using
     the `language` and `country` attributes of the `url` tag, or by specifying
-    e.g. the `{localization}` placeholder. For more information see
-    `Setup a Webspace <webspaces.html#urls>`_.
+    e.g. the `{localization}` placeholder. For more information see the
+    :ref:`URLs <webspace-urls>` of a webspace.
 
 Adding custom localizations
 ---------------------------

--- a/book/navigation.rst
+++ b/book/navigation.rst
@@ -1,0 +1,89 @@
+Navigation
+==========
+
+The navigation of a Sulu website is not hard-coded in the templates: the
+content manager decides which pages are shown in which navigation, and the
+developer renders it with the Twig functions shipped with Sulu.
+
+Navigation Contexts
+-------------------
+
+A webspace defines so called navigation contexts in the ``navigation`` section
+of its configuration (see :doc:`webspaces`). For many projects one or two
+contexts are enough:
+
+* The main navigation usually is the main entry point for the user of the
+  website.
+* A footer navigation can be useful for imprints and similar pages.
+
+.. code-block:: xml
+
+    <!-- config/webspaces/website.xml -->
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                    <title lang="de">Hauptnavigation</title>
+                </meta>
+            </context>
+            <context key="footer">
+                <meta>
+                    <title lang="en">Footer navigation</title>
+                    <title lang="de">Fußzeilennavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+The ``key`` of a context is what you pass to the Twig functions, the ``title``
+is what the content manager sees: while editing a page, the contexts the page
+belongs to are selected in *Settings > Navigation context*.
+
+The following screenshot shows the `Sulu homepage`_ with the main navigation on
+the top. As you can see the navigation returned for the navigation contexts are
+not necessarily flat, but can also contain sub pages.
+
+.. figure:: ../img/website-navigation-contexts.png
+    :align: center
+
+The navigation contexts can also be used in any other combination you want. The
+separation into main and footer navigation is only a quite common example.
+
+Rendering a Navigation
+----------------------
+
+The advantage of this method is that the content manager can decide on his own
+which pages to show in the navigation. This code shows an example for creating
+a nested navigation using all the pages marked to be shown in the main
+navigation context, up to two levels deep:
+
+.. code-block:: html+twig
+
+    <ul>
+        {% for item in sulu_page_navigation_root_tree('main', 2) %}
+        <li>
+            <a href="{{ sulu_content_path(item.url) }}"
+                title="{{ item.title }}">{{ item.title }}</a>
+            {% if item.children|length > 0 %}
+                <ul>
+                {% for child in item.children %}
+                    <li><a href="{{ sulu_content_path(child.url) }}"
+                            title="{{ child.title }}">
+                        {{ child.title }}
+                    </a></li>
+                {% endfor %}
+                </ul>
+            {% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+
+Sulu ships Twig functions for the usual cases: the whole tree of a context
+starting at the homepage (``sulu_page_navigation_root_tree``), a flat list of
+it (``sulu_page_navigation_root_flat``), or the sub navigation of a given page
+(``sulu_page_navigation_tree`` and ``sulu_page_navigation_flat``). Their
+parameters and the data returned for every page are described in the
+:doc:`Twig extensions reference <../reference/twig-extensions/index>`.
+
+.. _Sulu homepage: https://sulu.io/

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -43,7 +43,7 @@ The template of a page can be selected in the admin interface:
 .. note::
 
     If you don't want a template to appear in this list, use the ``excluded-templates`` node in the webspace configuration file.
-    Have a closer look at `Setup a Webspace <webspaces.html#urls>`_ for more details.
+    Have a closer look at the :doc:`webspace configuration reference <../bundles/page/webspace-configuration>` for more details.
 
 The name displayed in the dropdown is configured in the ``<meta>`` section of
 the XML:

--- a/book/twig.rst
+++ b/book/twig.rst
@@ -123,51 +123,11 @@ Other Variables
 Navigation
 ^^^^^^^^^^
 
-There is a Twig function that obtains the menu. You need to pass the key of the
-navigation context you defined in your webspace (:doc:`webspaces`).
-While editing a page the navigation context could be defined in
-*settings > Navigation context*. For many projects one or two navigation
-contexts might be enough:
-
-* The main navigation usually is the main entry point for the user of the
-  website.
-* A footer navigation can be useful for imprints and similar pages.
-
-The following screenshot shows the `Sulu homepage`_ with the main navigation on
-the top. As you can see the navigation returned for the navigation contexts are
-not necessarily flat, but can also contain sub pages.
-
-.. figure:: ../img/website-navigation-contexts.png
-    :align: center
-
-The navigation contexts can also be used in any other combination you want. The
-separation into main and footer navigation is only a quite common example.
-
-The advantage of this method is that the content manager can decide on his own
-which pages to show in the navigation. This code show an example for creating a
-nested navigation using all the pages marked to be shown in the main navigation
-context.
-
-.. code-block:: html
-
-    <ul>
-        {% for item in sulu_navigation_root_tree('main', 2) %}
-        <li>
-            <a href="{{ sulu_content_path(item.url) }}"
-                title="{{ item.title }}">{{ item.title }}</a>
-            {% if item.children|length > 0 %}
-                <ul>
-                {% for child in item.children %}
-                    <li><a href="{{ sulu_content_path(child.url) }}"
-                            title="{{ child.title }}">
-                        {{ child.title }}
-                    </a></li>
-                {% endfor %}
-                </ul>
-            {% endif %}
-        </li>
-        {% endfor %}
-    </ul>
+The pages assigned to a navigation context of the webspace are retrieved with
+the ``sulu_page_navigation_*`` Twig functions, e.g.
+``sulu_page_navigation_root_tree('main', 2)`` for the main navigation up to two
+levels deep. Read :doc:`navigation` for the configuration of the contexts and a
+complete rendering example.
 
 Images
 ^^^^^^

--- a/book/webspaces.rst
+++ b/book/webspaces.rst
@@ -1,9 +1,9 @@
 Setup a Webspace
 ================
 
-In this chapter we will have a look at webspaces. Therefore we will
-create a configuration for a basic website. This will result in a single portal
-website with multiple localizations.
+In this chapter we will have a look at webspaces. We will create the
+configuration of a basic website: a single webspace, published under one
+domain in multiple localizations.
 
 As already described in the section before, a webspace also creates a new
 content tree. These trees are accessible by the navigation in the Sulu
@@ -14,8 +14,8 @@ these trees and fill them with content. Have a closer look at
 Normally you'll create a webspace for a new website, a landingpage or a portal,
 that should run on your Sulu instance.
 
-The following file shows a configuration. These lines will be explained in the
-following paragraphs.
+The following file shows the configuration of such a webspace. These lines
+will be explained in the following paragraphs.
 
 .. code-block:: xml
 
@@ -27,27 +27,20 @@ following paragraphs.
         <name>Website</name>
         <key>website</key>
 
-        <security permission-check="true">
-            <system>website</system>
-        </security>
-
         <localizations>
             <localization language="en"/>
+            <localization language="de"/>
         </localizations>
 
         <default-templates>
             <default-template type="page">default</default-template>
-            <default-template type="homepage">default</default-template>
+            <default-template type="homepage">homepage</default-template>
         </default-templates>
 
         <templates>
             <template type="search">search/search</template>
             <template type="error">error/error</template>
         </templates>
-
-        <excluded-templates>
-            <excluded-template>overview</excluded-template>
-        </excluded-templates>
 
         <navigation>
             <contexts>
@@ -59,25 +52,6 @@ following paragraphs.
             </contexts>
         </navigation>
 
-        <segments>
-            <segment key="w" default="true">
-                <meta>
-                    <title lang="en">Winter</title>
-                    <title lang="de">Winter</title>
-                </meta>
-            </segment>
-            <segment key="s" default="false">
-                <meta>
-                    <title lang="en">Summer</title>
-                    <title lang="de">Sommer</title>
-                </meta>
-            </segment>
-        </segments>
-
-        <resource-locator>
-            <strategy>tree_leaf_edit</strategy>
-        </resource-locator>
-
         <portals>
             <portal>
                 <name>Website</name>
@@ -86,29 +60,18 @@ following paragraphs.
                 <environments>
                     <environment type="prod">
                         <urls>
-                            <url language="en">example.org</url>
+                            <url>example.org/{localization}</url>
                         </urls>
                     </environment>
                     <environment type="dev">
                         <urls>
-                            <url language="en">example.localhost</url>
+                            <url>example.localhost/{localization}</url>
                         </urls>
                     </environment>
                 </environments>
             </portal>
         </portals>
     </webspace>
-
-.. note::
-
-    If you want to match all hosts you can use the ``{host}`` placeholder.
-    Example: ``<url>{host}/{localization}</url>``
-
-.. note::
-
-    If you add a webspace to an existing installation you also have to set the
-    correct permissions for existing users, otherwise they won't be able to see
-    it.
 
 As you probably already have encountered, the root tag for our webspace
 definition is ``webspace``. Afterwards you see a name, which is displayed in the
@@ -117,34 +80,18 @@ internally to generate some files and define some paths. Therefore it is really
 important that the webspace key is unique across all webspaces in a single
 installation.
 
-Security (optional)
--------------------
-
-The ``security`` tag allows to define a separate security system in its
-``system`` tag. The security system will then be added as a possible option to
-choose for the system of a user role. With this relation it is possible to
-create roles specific to the Webspace's security system (see
-:doc:`../../cookbook/securing-your-application` for more information about
-security systems).
-
-If the ``permission-check`` attribute of the ``security`` tag is set to
-``true``, Sulu will automatically check if the current user has access to see
-the requested page. It will also make sure that no pages are listed in the
-website's navigation or in smart contents, if the user does not have the
-necessary permissions.
-
 .. note::
 
-    Make sure caching is set up correctly if you use the security feature with
-    the ``permission-check`` flag set to ``true``. The caching will only work
-    if you have configured the :doc:`../cookbook/user-context-caching`.
+    If you add a webspace to an existing installation you also have to set the
+    correct permissions for existing users, otherwise they won't be able to see
+    it.
 
 Localizations
 -------------
 
 In the ``localizations``-tag you can list all the available localizations in this
-webspace. In the example we are simply adding the English language, but you can
-also define country specific language if you add a country attribute to the
+webspace. In the example we are adding English and German, but you can also
+define country specific languages if you add a country attribute to the
 localization, so for instance the following tag would add Austrian German to
 the available localizations:
 
@@ -155,103 +102,54 @@ the available localizations:
 For a more complete explanation you should have a look at
 :doc:`localization`.
 
-Themes (optional)
+Default Templates
 -----------------
 
-The ``theme`` is described by a key. This key leads to a certain theme,
-implemented by a developer in the system. If you use multiple webspaces,
-which should have a different look and feel, you can easily accomplish
-this with the `SuluThemeBundle`_. Read more about the installation and usage
-in the `bundle documentation`_.
+The ``default-templates``-tag defines which of your :doc:`page templates
+<templates>` is preselected when a content manager creates a new page
+(``type="page"``) and which template is used for the homepage of the webspace
+(``type="homepage"``). The value is the key of the template, i.e. the name of
+its XML file without the extension.
 
 Templates
 ---------
 
-The webspace can also define certain templates in combination with a type.
-These templates can then be retrieved from the webspace. E.g. Sulu uses them to
-retrieve the correct templates for errors. Therefore it makes use of the
-template with type ``error-<http-code>`` respectively it uses the template with
-the type  ``error`` as a fallback. The other use case is the search. Sulu will
-use the template with the type ``search`` from the webspace to display search
-results.
-
-Excluded templates (optional)
------------------------------
-
-The ``excluded-templates`` node defines which of the templates (the ones
-described in :doc:`templates`) should be excluded in the template dropdown of
-the page form. The entire node is optional, since especially if you only have
-a single webspace this setting does not make a lot of sense.
+The ``templates``-tag defines the Twig templates Sulu itself renders for a
+webspace, by type. Sulu uses the template with the type ``error-<http-code>``
+(e.g. ``error-404``) to render an error page and falls back to the template
+with the type ``error``, and it uses the template with the type ``search`` to
+display the results of the website search.
 
 Navigation
 ----------
 
-It's also possible to define some so called navigation contexts, which allows
-the user to add pages to different kind of navigations. The different contexts
-can be defined in the ``navigation``-section, and this selection will be
-available to choose from in the administration interface. Afterwards the
-developer can retrieve the navigation for a given context by using some
-Twig-extensions delivered with Sulu, whereby it is not only possible to
-retrieve a flat list of pages, but also to retrieve entire navigation trees.
+The ``navigation``-tag defines so called navigation contexts, e.g. the main
+navigation and a footer navigation. A content manager can assign a page to
+one or more contexts, and the developer renders each context with the Twig
+functions shipped with Sulu. Read :doc:`navigation` for the details.
 
-Segments (optional)
--------------------
-
-For some website it makes sense to be displayed in multiple different segments.
-A segment is defined in the above ``segments`` tag and the main part is giving
-the segment a ``key``. Additionally a title for the segment to be displayed in
-the UI is defined.
-
-One of the segments must be set as the default. That's the segment a visitor
-sees when visiting the website for the very first time. The visitor can switch
-to a different segment in a similar way they can switch the localization. The
-current segment will be stored in a cookie. Sulu also takes care of the cookie
-when caching the website.
-
-After configuring segments for a webspace the segments can be assigned to pages
-in their "Excerpt & Taxonomies" tab. A page will then be hidden in navigation
-and smart contents if the page has a segment assigned and another segment is
-currently set for the visitor.
-
-Resource-Locator (optional)
----------------------------
-
-The URL of a page consists of the configured base URL of the webspace and a
-page-specific ``resource-locator``. If the ``resource-locator`` of a page is changed,
-Sulu will automatically redirect old URLs to the new URL per default. A webspace can set a
-``strategy`` for managing the ``resource-locator`` of its pages.
-
-The default strategy is ``tree_leaf_edit``, which means that the generated
-``resource-locator`` of a page includes all ancestors in the content tree, but only
-the last part will be editable. If the ``resource-locator`` of a page is changed, this
-strategy will also update the ``resource-locator`` of all child pages.
-
-The alternative ``tree_full_edit`` strategy also includes all ancestors when
-generating the ``resource-locator``, but it allows to edit the whole ``resource-locator``
-afterwards. If the ``resource-locator`` of a page is changed, this strategy does not update
-the ``resource-locator`` of the child pages.
-
-Portals
--------
-
-A webspace can itself consist of multiple portals. In our simple configuration
-file we make use of only one portal. The idea is that the same content can be
-shared among different portals and URLs. The portals can then also define for
-themselves in which localization they publish the content, so that you can
-spread different localizations over different URLs.
-
-Our sample file defines just one portal, which includes a ``name`` and a
-``key`` just as the webspace, whereby the key for the portal has to be unique
-for the entire installation, not only within this webspace.
+.. _webspace-urls:
 
 URLs
-~~~~
+----
 
-The most important part of the portal configuration are the environments,
-because they are including the URLs for the portal. A portal can have multiple
-environments, which have to match the environments defined in Symfony. Usually
-``dev``, ``stage`` and ``prod`` are available. Each environment can define its
-own set of URLs.
+A webspace can consist of multiple portals, but usually a single one is
+enough: it's the portal that defines under which URLs the content of the
+webspace is published. The portal has a ``name`` and a ``key`` like the
+webspace itself, whereby the key of the portal has to be unique for the entire
+installation, not only within this webspace.
+
+The URLs are defined per environment, which have to match the environments
+of Symfony: usually ``dev``, ``stage`` and ``prod`` are available. Each
+environment can define its own set of URLs, and every URL has to include the
+localization somehow, either by using a placeholder as in the example above
+(``{localization}`` expands to every localization of the webspace, resulting in
+``example.org/en`` and ``example.org/de``) or by fixing the URL to a specific
+localization:
+
+.. code-block:: xml
+
+    <url language="de" country="at">www.example.org</url>
 
 .. note::
 
@@ -259,52 +157,31 @@ own set of URLs.
     system will work with any port, so you don't have to name it in the
     configuration.
 
-The URLs also have to include the localization somehow. You have two
-possibilities to do so:
+.. tip::
 
-Fixing an URL to a specific localization
-........................................
+    If you want to match all hosts, e.g. during development, you can use the
+    ``{host}`` placeholder: ``<url>{host}/{localization}</url>``.
 
-The above example shows this possibility, where you fix one URL to exactly one
-localization. The following fragment shows again how to this:
+The available placeholders and the way to spread the localizations of a
+webspace over several portals are described in detail in the
+:doc:`webspace configuration reference <../bundles/page/webspace-configuration>`.
 
-.. code-block:: xml
+Further Configuration
+---------------------
 
-    <url language="de" country="at">www.example.org</url>
+The configuration above is all that is needed for most websites. The webspace
+schema offers some more, optional, tags, which are described in the
+:doc:`webspace configuration reference <../bundles/page/webspace-configuration>`:
 
-Since it is possible to define localizations without a country, this attribute
-is also optional here. However, the combination of language and country here
-must result in an existing localization.
-
-Using placeholders in the URL definition
-........................................
-
-Another possibility is to create the URL with a placeholder. Have a look at the
-following line for an example:
-
-.. code-block:: xml
-
-    <url>www.example.org/{localization}</url>
-
-Placeholder are expressions in curly braces, which will be expanded to every
-possible value. For the above example that means, that an URL for every
-localization defined will be generated. So if you have a localization ``de-at``
-and ``en-us``, the system will create URLs for ``www.example.org/de-at`` and
-``www.example.org/en-us``.
-
-In the following table all the possible placeholders are listed, and explains
-the values of them by using the ``de-at``-localization:
-
-+----------------+----------------------------------------+--------------------+
-| Placeholder    | Description                            | Example for `de-at`|
-+================+========================================+====================+
-| {localization} | The name of the entire localization    | `de-at`            |
-+----------------+----------------------------------------+--------------------+
-| {language}     | The name of the language               | `de`               |
-+----------------+----------------------------------------+--------------------+
-| {country}      | The name of the country, only makes    | `at`               |
-|                | sense in combination with `{language}` |                    |
-+----------------+----------------------------------------+--------------------+
-
-.. _SuluThemeBundle: https://github.com/sulu/SuluThemeBundle
-.. _bundle documentation: https://github.com/sulu/SuluThemeBundle
+* ``security``: restrict the pages of the webspace to the users of a separate
+  security system, with optional permission checks on the website;
+* ``theme``: use a different look and feel per webspace with the
+  SuluThemeBundle;
+* ``excluded-templates``: hide some page templates in the template dropdown of
+  this webspace;
+* ``segments``: split the website into segments (e.g. "Winter" and "Summer")
+  the visitor can switch between;
+* ``resource-locator``: choose how the URLs of the pages are generated and
+  updated;
+* ``portals``: publish the content of the webspace under several portals, with
+  different localizations and URLs each.

--- a/bundles/page/index.rst
+++ b/bundles/page/index.rst
@@ -7,6 +7,7 @@ content management functionality of Sulu, which is its most important part.
 .. toctree::
     :maxdepth: 2
 
+    webspace-configuration
     drafting
     versioning
     content-repository

--- a/bundles/page/webspace-configuration.rst
+++ b/bundles/page/webspace-configuration.rst
@@ -1,0 +1,252 @@
+Webspace Configuration
+======================
+
+This chapter is the reference of the webspace configuration files stored in
+``config/webspaces/``. The basics (localizations, templates, navigation
+contexts and URLs) are covered in :doc:`../../book/webspaces`; this page
+describes the optional tags and the advanced URL setups.
+
+A complete configuration looks as follows:
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="utf-8"?>
+    <webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+        <name>Website</name>
+        <key>website</key>
+
+        <security permission-check="true">
+            <system>website</system>
+        </security>
+
+        <localizations>
+            <localization language="en"/>
+        </localizations>
+
+        <theme>default</theme>
+
+        <default-templates>
+            <default-template type="page">default</default-template>
+            <default-template type="homepage">default</default-template>
+        </default-templates>
+
+        <templates>
+            <template type="search">search/search</template>
+            <template type="error">error/error</template>
+        </templates>
+
+        <excluded-templates>
+            <excluded-template>overview</excluded-template>
+        </excluded-templates>
+
+        <navigation>
+            <contexts>
+                <context key="main">
+                    <meta>
+                        <title lang="en">Mainnavigation</title>
+                    </meta>
+                </context>
+            </contexts>
+        </navigation>
+
+        <segments>
+            <segment key="w" default="true">
+                <meta>
+                    <title lang="en">Winter</title>
+                    <title lang="de">Winter</title>
+                </meta>
+            </segment>
+            <segment key="s" default="false">
+                <meta>
+                    <title lang="en">Summer</title>
+                    <title lang="de">Sommer</title>
+                </meta>
+            </segment>
+        </segments>
+
+        <resource-locator>
+            <strategy>tree_leaf_edit</strategy>
+        </resource-locator>
+
+        <portals>
+            <portal>
+                <name>Website</name>
+                <key>website</key>
+
+                <environments>
+                    <environment type="prod">
+                        <urls>
+                            <url language="en">example.org</url>
+                        </urls>
+                    </environment>
+                    <environment type="dev">
+                        <urls>
+                            <url language="en">example.localhost</url>
+                        </urls>
+                    </environment>
+                </environments>
+            </portal>
+        </portals>
+    </webspace>
+
+Security
+--------
+
+The ``security`` tag allows to define a separate security system in its
+``system`` tag. The security system will then be added as a possible option to
+choose for the system of a user role. With this relation it is possible to
+create roles specific to the Webspace's security system (see
+:doc:`../../cookbook/securing-your-application` for more information about
+security systems).
+
+If the ``permission-check`` attribute of the ``security`` tag is set to
+``true``, Sulu will automatically check if the current user has access to see
+the requested page. It will also make sure that no pages are listed in the
+website's navigation or in smart contents, if the user does not have the
+necessary permissions.
+
+.. note::
+
+    Make sure caching is set up correctly if you use the security feature with
+    the ``permission-check`` flag set to ``true``. The caching will only work
+    if you have configured the :doc:`../../cookbook/user-context-caching`.
+
+Themes
+------
+
+The ``theme`` is described by a key. This key leads to a certain theme,
+implemented by a developer in the system. If you use multiple webspaces,
+which should have a different look and feel, you can easily accomplish
+this with the `SuluThemeBundle`_. Read more about the installation and usage
+in the `bundle documentation`_.
+
+Excluded Templates
+------------------
+
+The ``excluded-templates`` node defines which of the templates (the ones
+described in :doc:`../../book/templates`) should be excluded in the template
+dropdown of the page form. The entire node is optional, since especially if
+you only have a single webspace this setting does not make a lot of sense.
+
+Segments
+--------
+
+For some websites it makes sense to be displayed in multiple different
+segments. A segment is defined in the above ``segments`` tag and the main part
+is giving the segment a ``key``. Additionally a title for the segment to be
+displayed in the UI is defined.
+
+One of the segments must be set as the default. That's the segment a visitor
+sees when visiting the website for the very first time. The visitor can switch
+to a different segment in a similar way they can switch the localization. The
+current segment will be stored in a cookie. Sulu also takes care of the cookie
+when caching the website.
+
+After configuring segments for a webspace the segments can be assigned to pages
+in their "Excerpt & Taxonomies" tab. A page will then be hidden in navigation
+and smart contents if the page has a segment assigned and another segment is
+currently set for the visitor.
+
+Resource Locator
+----------------
+
+The URL of a page consists of the configured base URL of the webspace and a
+page-specific ``resource-locator``. If the ``resource-locator`` of a page is changed,
+Sulu will automatically redirect old URLs to the new URL per default. A webspace can set a
+``strategy`` for managing the ``resource-locator`` of its pages.
+
+The default strategy is ``tree_leaf_edit``, which means that the generated
+``resource-locator`` of a page includes all ancestors in the content tree, but only
+the last part will be editable. If the ``resource-locator`` of a page is changed, this
+strategy will also update the ``resource-locator`` of all child pages.
+
+The alternative ``tree_full_edit`` strategy also includes all ancestors when
+generating the ``resource-locator``, but it allows to edit the whole ``resource-locator``
+afterwards. If the ``resource-locator`` of a page is changed, this strategy does not update
+the ``resource-locator`` of the child pages.
+
+Portals
+-------
+
+A webspace can itself consist of multiple portals. In our simple configuration
+file we make use of only one portal. The idea is that the same content can be
+shared among different portals and URLs. The portals can then also define for
+themselves in which localization they publish the content, so that you can
+spread different localizations over different URLs.
+
+Our sample file defines just one portal, which includes a ``name`` and a
+``key`` just as the webspace, whereby the key for the portal has to be unique
+for the entire installation, not only within this webspace.
+
+URLs
+~~~~
+
+The most important part of the portal configuration are the environments,
+because they are including the URLs for the portal. A portal can have multiple
+environments, which have to match the environments defined in Symfony. Usually
+``dev``, ``stage`` and ``prod`` are available. Each environment can define its
+own set of URLs.
+
+.. note::
+
+    Please consider that you have to omit the port in the configuration. The
+    system will work with any port, so you don't have to name it in the
+    configuration.
+
+The URLs also have to include the localization somehow. You have two
+possibilities to do so:
+
+Fixing an URL to a specific localization
+........................................
+
+The above example shows this possibility, where you fix one URL to exactly one
+localization. The following fragment shows again how to this:
+
+.. code-block:: xml
+
+    <url language="de" country="at">www.example.org</url>
+
+Since it is possible to define localizations without a country, this attribute
+is also optional here. However, the combination of language and country here
+must result in an existing localization.
+
+Using placeholders in the URL definition
+........................................
+
+Another possibility is to create the URL with a placeholder. Have a look at the
+following line for an example:
+
+.. code-block:: xml
+
+    <url>www.example.org/{localization}</url>
+
+Placeholder are expressions in curly braces, which will be expanded to every
+possible value. For the above example that means, that an URL for every
+localization defined will be generated. So if you have a localization ``de-at``
+and ``en-us``, the system will create URLs for ``www.example.org/de-at`` and
+``www.example.org/en-us``.
+
+.. note::
+
+    If you want to match all hosts you can use the ``{host}`` placeholder.
+    Example: ``<url>{host}/{localization}</url>``
+
+In the following table all the possible placeholders are listed, and explains
+the values of them by using the ``de-at``-localization:
+
++----------------+----------------------------------------+--------------------+
+| Placeholder    | Description                            | Example for `de-at`|
++================+========================================+====================+
+| {localization} | The name of the entire localization    | `de-at`            |
++----------------+----------------------------------------+--------------------+
+| {language}     | The name of the language               | `de`               |
++----------------+----------------------------------------+--------------------+
+| {country}      | The name of the country, only makes    | `at`               |
+|                | sense in combination with `{language}` |                    |
++----------------+----------------------------------------+--------------------+
+
+.. _SuluThemeBundle: https://github.com/sulu/SuluThemeBundle
+.. _bundle documentation: https://github.com/sulu/SuluThemeBundle


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes #908
| Related PRs | #930 (touches the same paragraph of `getting-started.rst`, trivial to merge either way)
| License | MIT

#### What's in this PR?

Follows the split proposed in #908:

- `book/webspaces.rst` ("Setup a Webspace") now only covers what a project needs to get started: a minimal configuration, then **Localizations**, **Default Templates** (which had no section so far), **Templates**, **Navigation** (short, linking to the new chapter) and **URLs** (single portal, placeholder or fixed localization). A closing "Further Configuration" section mentions the optional tags in one line each and links to the reference.
- `bundles/page/webspace-configuration.rst` (new, in the PageBundle toctree) is the in-depth reference: the complete XML, **Security**, **Themes**, **Excluded Templates**, **Segments**, **Resource Locator**, **Portals** with the environments, URL variants and placeholders table. The text is the existing one, moved, not rewritten.
- `book/navigation.rst` (new, in the book toctree after "Setup a Webspace") gathers the navigation contexts (configuration and what the content manager sees) and their rendering in Twig, which were split between `webspaces.rst` and `twig.rst#navigation`. The "Navigation" heading of `twig.rst` stays, with a pointer to the chapter, so existing anchors keep working.
- The two links to `webspaces.html#urls` from `templates.rst` and `localization.rst` now point to the right place (the excluded templates reference and a `webspace-urls` label respectively), and the "Webspaces" paragraph of the getting started announces what the webspace chapter covers.

No page is renamed or removed, so no redirect is needed. `sphinx-build -n -W` passes.

#### Why?

See #908: the "Setup a Webspace" chapter had grown into a full reference, which is too much for the getting started path, and the navigation was documented in two halves.
