### PR TITLE
Document the parallel image generation limit

### DIFF
--- a/bundles/media/configuration.rst
+++ b/bundles/media/configuration.rst
@@ -40,17 +40,25 @@ free slot before their image is generated:
 
 The limit is shared between all the PHP workers of the application through a
 semaphore of the `Symfony Semaphore component`_, using the storage configured
-under ``framework.semaphore`` (e.g. a Redis DSN):
+under ``framework.semaphore``. The ``lock://`` storage works out of the box,
+without any extra service:
 
 .. code-block:: bash
 
-    composer require symfony/semaphore
+    composer require symfony/semaphore symfony/lock
 
 .. code-block:: yaml
 
+    # config/packages/lock.yaml
+    framework:
+        lock: '%env(LOCK_DSN)%'
+
     # config/packages/semaphore.yaml
     framework:
-        semaphore: 'redis://localhost'
+        semaphore: 'lock://'
+
+The ``lock://`` storage requires ``symfony/semaphore`` 8.1. On older versions,
+configure a Redis DSN instead (``semaphore: 'redis://localhost'``).
 
 When no slot becomes available within one minute, the request fails: the limit
 protects the server, generating the image anyway would defeat it.

--- a/bundles/media/configuration.rst
+++ b/bundles/media/configuration.rst
@@ -18,3 +18,41 @@ The SuluMediaBundle can be configured the following way:
                 - video/quicktime
                 - video/x-msvideo
                 - video/x-ms-wmv
+
+Limiting the parallel image generation
+--------------------------------------
+
+Image formats are generated on the fly the first time they are requested. When
+many uncached formats are requested at once (e.g. when a large media collection
+is opened in the administration interface for the first time), every PHP worker
+generates an image at the same time, which can exhaust the memory of the
+server. The ``parallel_image_generation.limit`` option limits the number of
+HTTP requests generating an image concurrently; the other requests wait for a
+free slot before their image is generated:
+
+.. code-block:: yaml
+
+    # config/packages/sulu_media.yaml
+    sulu_media:
+        format_manager:
+            parallel_image_generation:
+                limit: 4
+
+The limit is shared between all the PHP workers of the application through a
+semaphore of the `Symfony Semaphore component`_, using the storage configured
+under ``framework.semaphore`` (e.g. a Redis DSN):
+
+.. code-block:: bash
+
+    composer require symfony/semaphore
+
+.. code-block:: yaml
+
+    # config/packages/semaphore.yaml
+    framework:
+        semaphore: 'redis://localhost'
+
+When no slot becomes available within one minute, the request fails: the limit
+protects the server, generating the image anyway would defeat it.
+
+.. _`Symfony Semaphore component`: https://symfony.com/doc/current/components/semaphore.html


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | -
| Related PRs | sulu/sulu#9041 |
| License | MIT

#### What's in this PR?

Documents the `sulu_media.format_manager.max_parallel_image_generation_limit` and `max_parallel_image_generation_wait_time` options added in sulu/sulu#9041 (sulu/sulu#8735): a "Limiting the parallel image generation" section on the media configuration page, with the problem it solves, the YAML snippet, the Semaphore/Lock requirements and the wait behavior. To be merged together with (or after) the feature PR.

#### Why?

New configuration options, otherwise undiscoverable.
