### PR TITLE
Init SiteMap Docs

### DIFF
--- a/cookbook/sitemap-provider.rst
+++ b/cookbook/sitemap-provider.rst
@@ -1,7 +1,8 @@
 Provider for XML-Sitemap
 ========================
 
-``SitemapProvider`` classes are used to load data for the XML sitemap. Each provider
+``SitemapProvider`` classes are used to load data for the XML sitemap and for the
+:doc:`sulu_sitemap </reference/twig-extensions/functions/sulu_sitemap>` Twig function. Each provider
 returns an array of ``SitemapUrl`` instances. The API is paginated because Google
 limits a single sitemap file to 50,000 URLs. The ``SitemapController`` generates a
 ``sitemapindex`` automatically when more than one provider exists or when a provider
@@ -16,6 +17,9 @@ The ``SitemapUrl`` constructor accepts the following arguments:
 * ``changefreq`` (optional) - Frequency of change (see ``SitemapUrl::CHANGE_FREQUENCY_*`` constants).
 * ``priority`` (optional) - Priority of page relative to other pages (float).
 * ``attributes`` (optional) - Additional attributes passed to the sitemap template.
+* ``title`` (optional) - Human readable title of the URL. It is not rendered into the XML sitemap, but it
+  is used as link text by the ``sulu_sitemap`` Twig function, so set it if your entity should show up with
+  a readable label in a human readable sitemap.
 * ``alternateLinks`` (optional) - Added via ``addAlternateLink()`` after construction.
 
 Sulu provides built-in providers for pages (including the homepage) and, when
@@ -57,7 +61,8 @@ for a given host.
                     $scheme . '://' . $host . $item->getUrl(),
                     $item->getLocale(),
                     $item->getDefaultLocale(),
-                    $item->getChanged()
+                    $item->getChanged(),
+                    title: $item->getTitle()
                 );
             }
 
@@ -93,3 +98,8 @@ If you have disabled autowiring, add the tag manually:
     App\Sitemap\ExampleSitemapProvider:
         tags:
             - { name: sulu.sitemap.provider }
+
+Once the provider is registered, its URLs appear in ``/sitemap.xml``, in
+:doc:`sulu_sitemap </reference/twig-extensions/functions/sulu_sitemap>` and under its alias in
+:doc:`sulu_sitemap_aliases </reference/twig-extensions/functions/sulu_sitemap_aliases>` - no further
+wiring is required.

--- a/reference/twig-extensions/functions/sulu_sitemap.rst
+++ b/reference/twig-extensions/functions/sulu_sitemap.rst
@@ -1,14 +1,86 @@
-:orphan:
-
 ``sulu_sitemap``
 ================
 
+Returns the URLs of all registered :doc:`sitemap providers </cookbook/sitemap-provider>` for the host of
+the current request. This is the same data source the XML sitemap (``/sitemap.xml``) is rendered from, so
+a human readable sitemap contains pages, articles and every other routable entity which registers a
+sitemap provider, and both sitemaps can not drift apart.
+
+Content which has *Hide in sitemap* enabled in its SEO settings is excluded, the same way it is excluded
+from the XML sitemap.
+
+**Example**:
+
+.. code-block:: twig
+
+    <ul>
+        {% for entry in sulu_sitemap() %}
+            <li>
+                <a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+
+The ``loc`` of an entry is already an absolute URL, therefore
+:doc:`sulu_sitemap_url </reference/twig-extensions/functions/sulu_sitemap_url>` is not needed here.
+
+**Grouped Example**:
+
+Pass the alias of a single provider to render one section per content type. The available aliases can be
+read with :doc:`sulu_sitemap_aliases </reference/twig-extensions/functions/sulu_sitemap_aliases>`.
+
+.. code-block:: twig
+
+    {% for alias in sulu_sitemap_aliases() %}
+        <h2>{{ ('sitemap.' ~ alias)|trans }}</h2>
+
+        <ul>
+            {% for entry in sulu_sitemap(alias: alias) %}
+                <li>
+                    <a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a>
+
+                    {% if entry.lastmod %}
+                        <time datetime="{{ entry.lastmod|date('c') }}">{{ entry.lastmod|date('d.m.Y') }}</time>
+                    {% endif %}
+                </li>
+            {% endfor %}
+        </ul>
+    {% endfor %}
+
+**Arguments**:
+
+- **locale**: *string|null* - optional: locale to filter the URLs by. Defaults to the locale of the
+  current request, ``null`` returns the URLs of all locales of the host.
+- **alias**: *string|null* - optional: alias of a single sitemap provider, e.g. ``pages`` or ``articles``.
+  Defaults to ``null``, which collects the URLs of all providers.
+- **page**: *int* - optional: page of the sitemap providers. Providers are paginated with 50,000 URLs per
+  page (``SitemapProviderInterface::PAGE_SIZE``). Defaults to ``1``.
+
+**Returns**:
+
+An array of ``Sulu\Bundle\WebsiteBundle\Sitemap\SitemapUrl`` objects with the following properties:
+
+- **loc**: *string* - absolute URL of the entry.
+- **title**: *string|null* - human readable title. Set by the page and article providers,
+  :doc:`custom providers </cookbook/sitemap-provider>` may leave it empty.
+- **locale**: *string* - locale of the entry.
+- **defaultLocale**: *string|null* - default locale of the webspace.
+- **lastmod**: *\\DateTimeInterface|null* - datetime of the last modification.
+- **changefreq**: *string|null* - frequency of change.
+- **priority**: *float|null* - priority relative to the other URLs.
+- **alternateLinks**: *array* - alternate links keyed by locale, each with ``href`` and ``locale``.
+- **attributes**: *array* - additional attributes provided by the sitemap provider.
+
 .. note::
 
-    This extension was removed in Sulu 3.0.
+    Collecting the URLs queries every registered provider, so avoid calling this function in a partial
+    which is rendered on every page. Repeated calls with the same arguments are served from an in-memory
+    cache which lives for the duration of a request. Its lifetime can be configured:
 
-    The previous extension did not keep articles or other routable content in mind.
-    To bring this feature back we require deeper feedback from the community about the use-cases.
-    Please provide your feedback on GitHub `Sitemap Twig Extension for Sulu 3 issue`_ .
+    .. code-block:: yaml
 
-.. _Sitemap Twig Extension for Sulu 3 issue: https://github.com/sulu/sulu/issues/8580
+        # config/packages/sulu_website.yaml
+        sulu_website:
+            twig:
+                sitemap:
+                    cache_lifetime: 3600

--- a/reference/twig-extensions/functions/sulu_sitemap_aliases.rst
+++ b/reference/twig-extensions/functions/sulu_sitemap_aliases.rst
@@ -1,0 +1,29 @@
+``sulu_sitemap_aliases``
+========================
+
+Returns the aliases of all registered :doc:`sitemap providers </cookbook/sitemap-provider>`, e.g.
+``['pages', 'articles']``. Use it together with
+:doc:`sulu_sitemap </reference/twig-extensions/functions/sulu_sitemap>` to render one section per content
+type without hardcoding the aliases.
+
+**Example**:
+
+.. code-block:: twig
+
+    {% for alias in sulu_sitemap_aliases() %}
+        <h2>{{ ('sitemap.' ~ alias)|trans }}</h2>
+
+        <ul>
+            {% for entry in sulu_sitemap(alias: alias) %}
+                <li>
+                    <a href="{{ entry.loc }}">{{ entry.title|default(entry.loc) }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    {% endfor %}
+
+**Arguments**:
+
+None.
+
+**Returns**: *string[]* - aliases of the registered sitemap providers

--- a/reference/twig-extensions/functions/sulu_sitemap_url.rst
+++ b/reference/twig-extensions/functions/sulu_sitemap_url.rst
@@ -1,14 +1,31 @@
-:orphan:
-
 ``sulu_sitemap_url``
 ====================
 
-.. note::
+Returns the absolute URL for a given slug, including scheme and domain. Use it when you have a bare slug
+and need a URL which is also valid outside of the current request, for example in a sitemap, a feed or an
+email. Within the website
+:doc:`sulu_content_path </reference/twig-extensions/functions/sulu_content_path>` is usually the better
+choice, because it returns a relative path.
 
-    This extension was removed in Sulu 3.0.
+The entries returned by :doc:`sulu_sitemap </reference/twig-extensions/functions/sulu_sitemap>` already
+contain an absolute ``loc``, so this function is not needed for them.
 
-    The previous extension did not keep articles or other routable content in mind.
-    To bring this feature back we require deeper feedback from the community about the use-cases.
-    Please provide your feedback on GitHub `Sitemap Twig Extension for Sulu 3 issue`_ .
+**Example**:
 
-.. _Sitemap Twig Extension for Sulu 3 issue: https://github.com/sulu/sulu/issues/8580
+.. code-block:: twig
+
+    <a href="{{ sulu_sitemap_url('/products') }}">{{ 'products'|trans }}</a>
+
+    {# a slug of another webspace and locale #}
+    <a href="{{ sulu_sitemap_url('/products', 'en', 'other_io') }}">{{ 'products'|trans }}</a>
+
+**Arguments**:
+
+- **slug**: *string|null* - slug to resolve, e.g. ``/products``
+- **locale**: *string|null* - optional: locale to resolve the URL for. Defaults to the locale of the
+  current request.
+- **webspaceKey**: *string|null* - optional: webspace to resolve the URL for. Defaults to the webspace of
+  the current request.
+
+**Returns**: *string|null* - absolute URL, or ``null`` if no URL is configured for the given webspace and
+locale

--- a/reference/twig-extensions/index.rst
+++ b/reference/twig-extensions/index.rst
@@ -21,6 +21,9 @@ Functions
     functions/sulu_page_navigation_flat
     functions/sulu_page_navigation_root_flat
     functions/sulu_page_navigation_tree
+    functions/sulu_sitemap
+    functions/sulu_sitemap_aliases
+    functions/sulu_sitemap_url
 
 Filters
 ~~~~~~~


### PR DESCRIPTION
| Q | A
| --- | ---
| Fixed tickets | fixes sulu/sulu#8580
| Related PRs | sulu/sulu#9052
| License | MIT

#### What's in this PR?

Documents the `sulu_sitemap` Twig functions which sulu/sulu#PRNUM re-adds.

* `reference/twig-extensions/functions/sulu_sitemap.rst` — replaces the "removed in Sulu 3.0" stub.
  Describes the new provider-based behaviour, a flat and a grouped example, the arguments
  (`locale`, `alias`, `page`) and every property of the returned `SitemapUrl` objects, plus a note about
  the query cost, the 50,000 URLs per page limit and the `cache_lifetime` option.
* `reference/twig-extensions/functions/sulu_sitemap_url.rst` — replaces the stub as well and now clearly
  delimits the function from `sulu_content_path` (absolute URL vs. relative path), including the hint that
  `sulu_sitemap` entries already carry an absolute `loc`.
* `reference/twig-extensions/functions/sulu_sitemap_aliases.rst` — new page.
* `reference/twig-extensions/index.rst` — lists the three pages in the `CoreBundle` toctree, where they
  were listed in 2.x too, so the `:orphan:` markers could be dropped.
* `cookbook/sitemap-provider.rst` — documents the new optional `title` argument of `SitemapUrl` (used as
  link text by `sulu_sitemap`, not rendered into the XML sitemap), adds it to the example provider, and
  states that a registered provider automatically shows up in `/sitemap.xml`, in `sulu_sitemap` and in
  `sulu_sitemap_aliases`.

Sphinx builds without warnings, and the `:doc:` cross-references between the reference pages and the
cookbook resolve in both directions.

#### Why?

`sulu_sitemap` and `sulu_sitemap_url` were removed in 3.0 together with the PHPCR services, and both
reference pages only carried a note pointing at sulu/sulu#8580. sulu/sulu#PRNUM brings the functions back
on top of the sitemap providers, which also closes the gap the old implementation had: it read pages from
a PHPCR query and therefore never saw articles or custom routable entities. The documentation has to
describe the new data source, the changed arguments and the new `title` for custom providers, otherwise
users porting templates from 2.x will keep hitting the removal note.