### PR TITLE
Document template groups for articles and snippets

### DIFF
--- a/book/templates.rst
+++ b/book/templates.rst
@@ -949,6 +949,74 @@ node and the ``ref`` attribute:
     to avoid confusion. This approach also simplifies the transition to global blocks in the future, eliminating the need
     for data migrations.
 
+.. _templates-template-groups:
+
+Template Groups
+----------------
+
+.. note::
+
+    Template groups are available for article and snippet templates only. Page templates do not
+    support the ``<group>`` element.
+
+If you have many templates of the same type, you can organize them into groups by adding a
+``<group>`` element next to the ``<key>``:
+
+.. code-block:: xml
+
+    <!-- config/templates/articles/news.xml -->
+    <?xml version="1.0" ?>
+    <template xmlns="http://schemas.sulu.io/template/template"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+        <key>news</key>
+        <group>news</group>
+
+        <!-- ... -->
+    </template>
+
+Templates without a ``<group>`` element land in the implicit ``default`` group.
+
+Grouping templates this way changes the administration interface for the corresponding resource
+(articles or snippets):
+
+* The list is split into one tab per group, each showing only the entries that use a template from
+  that group.
+* The "Add" and "Edit" forms of a group only offer the templates belonging to that group.
+* Every group other than ``default`` registers its own security context, e.g.
+  ``sulu.article.articles_news`` or ``sulu.snippet.snippets_news``, so access can be granted or
+  denied per group. See :doc:`../bundles/security/index` for more on security contexts. Remember to
+  grant the new context to the roles that need it. The ``default`` group and setups with only one
+  group keep using the resource's regular security context (``sulu.article.articles`` /
+  ``sulu.snippet.snippets``).
+* Selection fields such as |snippet_selection|, |single_snippet_selection|,
+  :doc:`article_selection <../reference/property-types/article_selection>` or
+  :doc:`single_article_selection <../reference/property-types/single_article_selection>`, and the
+  article/snippet smart content, can be restricted to specific groups with the ``groups``
+  parameter:
+
+.. code-block:: xml
+
+    <property name="relatedNews" type="article_selection">
+        <meta>
+            <title lang="en">Related News</title>
+        </meta>
+        <params>
+            <param name="groups" value="news"/>
+        </params>
+    </property>
+
+The group title shown in the administration interface comes from the translation key
+``sulu_admin.template_group.<group>`` and falls back to the capitalized group identifier if no
+translation exists.
+
+.. note::
+
+    Groups are also picked up by the admin search index. After adding or renaming a group, run
+    ``bin/console cmsig:seal:reindex`` for both kernels so search results deep-link into the correct
+    group.
+
 Caching
 -------
 

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -981,8 +981,8 @@ context (e.g. ``sulu.article.articles_marketing``, see :doc:`../bundles/security
 be granted to the roles that need it; selection fields and smart content for the resource can be
 filtered by group too, see e.g. :doc:`../reference/property-types/snippet_selection`.
 
-The group title shown in the administration interface — for every group, including the implicit
-``default`` group — comes from the translation key ``sulu_admin.template_group.<group>`` and falls
+The group title shown in the administration interface, for every group including the implicit
+``default`` group, comes from the translation key ``sulu_admin.template_group.<group>`` and falls
 back to the capitalized group identifier if no translation exists.
 
 .. note::

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -973,9 +973,7 @@ the same type, you can organize them into groups by adding a ``<group>`` element
         <!-- ... -->
     </template>
 
-Templates without a ``<group>`` element land in the implicit ``default`` group, whose tab title
-falls back to the plain word "Default" unless your project adds a translation for
-``sulu_admin.template_group.default`` (see below).
+Templates without a ``<group>`` element land in the implicit ``default`` group.
 
 Grouping templates this way splits the list into one tab per group, restricts each group's "Add" and
 "Edit" forms to that group's templates, and gives every group other than ``default`` its own security
@@ -983,9 +981,9 @@ context (e.g. ``sulu.article.articles_marketing``, see :doc:`../bundles/security
 be granted to the roles that need it; selection fields and smart content for the resource can be
 filtered by group too, see e.g. :doc:`../reference/property-types/snippet_selection`.
 
-The group title shown in the administration interface comes from the translation key
-``sulu_admin.template_group.<group>`` and falls back to the capitalized group identifier if no
-translation exists.
+The group title shown in the administration interface — for every group, including the implicit
+``default`` group — comes from the translation key ``sulu_admin.template_group.<group>`` and falls
+back to the capitalized group identifier if no translation exists.
 
 .. note::
 

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -973,7 +973,9 @@ the same type, you can organize them into groups by adding a ``<group>`` element
         <!-- ... -->
     </template>
 
-Templates without a ``<group>`` element land in the implicit ``default`` group.
+Templates without a ``<group>`` element land in the implicit ``default`` group, whose tab title
+falls back to the plain word "Default" unless your project adds a translation for
+``sulu_admin.template_group.default`` (see below).
 
 Grouping templates this way splits the list into one tab per group, restricts each group's "Add" and
 "Edit" forms to that group's templates, and gives every group other than ``default`` its own security

--- a/book/templates.rst
+++ b/book/templates.rst
@@ -954,58 +954,32 @@ node and the ``ref`` attribute:
 Template Groups
 ----------------
 
-.. note::
-
-    Template groups are available for article and snippet templates only. Page templates do not
-    support the ``<group>`` element.
-
-If you have many templates of the same type, you can organize them into groups by adding a
-``<group>`` element next to the ``<key>``:
+Template groups are available for article templates (since Sulu 3.0) and snippet templates (since
+Sulu 3.1) only; page templates do not support the ``<group>`` element. If you have many templates of
+the same type, you can organize them into groups by adding a ``<group>`` element next to the
+``<key>``:
 
 .. code-block:: xml
 
-    <!-- config/templates/articles/news.xml -->
+    <!-- config/templates/articles/event.xml -->
     <?xml version="1.0" ?>
     <template xmlns="http://schemas.sulu.io/template/template"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
 
-        <key>news</key>
-        <group>news</group>
+        <key>event</key>
+        <group>marketing</group>
 
         <!-- ... -->
     </template>
 
 Templates without a ``<group>`` element land in the implicit ``default`` group.
 
-Grouping templates this way changes the administration interface for the corresponding resource
-(articles or snippets):
-
-* The list is split into one tab per group, each showing only the entries that use a template from
-  that group.
-* The "Add" and "Edit" forms of a group only offer the templates belonging to that group.
-* Every group other than ``default`` registers its own security context, e.g.
-  ``sulu.article.articles_news`` or ``sulu.snippet.snippets_news``, so access can be granted or
-  denied per group. See :doc:`../bundles/security/index` for more on security contexts. Remember to
-  grant the new context to the roles that need it. The ``default`` group and setups with only one
-  group keep using the resource's regular security context (``sulu.article.articles`` /
-  ``sulu.snippet.snippets``).
-* Selection fields such as |snippet_selection|, |single_snippet_selection|,
-  :doc:`article_selection <../reference/property-types/article_selection>` or
-  :doc:`single_article_selection <../reference/property-types/single_article_selection>`, and the
-  article/snippet smart content, can be restricted to specific groups with the ``groups``
-  parameter:
-
-.. code-block:: xml
-
-    <property name="relatedNews" type="article_selection">
-        <meta>
-            <title lang="en">Related News</title>
-        </meta>
-        <params>
-            <param name="groups" value="news"/>
-        </params>
-    </property>
+Grouping templates this way splits the list into one tab per group, restricts each group's "Add" and
+"Edit" forms to that group's templates, and gives every group other than ``default`` its own security
+context (e.g. ``sulu.article.articles_marketing``, see :doc:`../bundles/security/index`) that has to
+be granted to the roles that need it; selection fields and smart content for the resource can be
+filtered by group too, see e.g. :doc:`../reference/property-types/snippet_selection`.
 
 The group title shown in the administration interface comes from the translation key
 ``sulu_admin.template_group.<group>`` and falls back to the capitalized group identifier if no

--- a/bundles/snippet.rst
+++ b/bundles/snippet.rst
@@ -105,9 +105,9 @@ Properties are the same as Page :doc:`../book/templates`.
 Grouping Snippet Templates
 ---------------------------
 
-If your project has many snippet templates, you can organize them into groups, e.g. to give
-"Events" and "Marketing" snippets their own tab in the snippet list. Add a ``<group>`` element to
-each template:
+Available since Sulu 3.1. If your project has many snippet templates, you can organize them into
+groups, e.g. to give "Events" and "Marketing" snippets their own tab in the snippet list. Add a
+``<group>`` element to each template:
 
 .. code-block:: xml
 

--- a/bundles/snippet.rst
+++ b/bundles/snippet.rst
@@ -102,6 +102,24 @@ Properties
 Properties are the same as Page :doc:`../book/templates`.
 
 
+Grouping Snippet Templates
+---------------------------
+
+If your project has many snippet templates, you can organize them into groups, e.g. to give
+"Events" and "Marketing" snippets their own tab in the snippet list. Add a ``<group>`` element to
+each template:
+
+.. code-block:: xml
+
+    <!-- config/templates/snippets/social_media.xml -->
+    <key>social_media</key>
+    <group>marketing</group>
+
+See :ref:`templates-template-groups` for the full explanation, including the ``groups`` parameter for
+:doc:`../reference/property-types/snippet_selection` and
+:doc:`../reference/property-types/single_snippet_selection`, and how groups affect security contexts.
+
+
 Implement a Snippet in your Template
 ------------------------------------
 

--- a/reference/property-types/single_snippet_selection.rst
+++ b/reference/property-types/single_snippet_selection.rst
@@ -17,9 +17,14 @@ Parameters
     * - Parameter
       - Type
       - Description
-    * - types
+    * - templateKeys
       - string
-      - If set, only snippets of the type can be selected.
+      - Comma separated list of template keys. If set, only snippets using one of these templates
+        can be selected.
+    * - groups
+      - string
+      - Comma separated list of group identifiers, available since Sulu 3.1. If set, only snippets
+        belonging to one of these groups can be selected. See :ref:`templates-template-groups`.
     * - default
       - string
       - If set, the default snippet of the given area will be used as fallback value if no snippet is selected.
@@ -49,7 +54,7 @@ Example
         </meta>
 
         <params>
-            <param name="types" value="default"/>
+            <param name="templateKeys" value="default"/>
             <param name="default" value="footer_social_media_links"/>
         </params>
     </property>

--- a/reference/property-types/smart_content.rst
+++ b/reference/property-types/smart_content.rst
@@ -75,13 +75,14 @@ Parameters
         records when the provider supports duplicate detection. Default: `false`
     * - groups
       - string
-      - Articles only (``articles`` and ``articles_page_tree`` providers): comma
-        separated list of article group identifiers to pre-filter the result set.
+      - Comma separated list of group identifiers to pre-filter the result set. Supported by the
+        ``articles`` and ``articles_page_tree`` providers, and by the ``snippets`` provider since
+        Sulu 3.1. See :ref:`templates-template-groups`.
     * - templateKeys
       - string
       - Comma separated list of template keys to pre-filter the result set. Supported
-        by the ``pages``, ``snippets`` and ``article`` providers. For articles the value
-        is intersected with the templates resolved from ``groups``.
+        by the ``pages``, ``snippets`` and ``articles`` providers. For articles and snippets the
+        value is intersected with the templates resolved from ``groups``.
 
 Return Value
 ------------

--- a/reference/property-types/snippet_selection.rst
+++ b/reference/property-types/snippet_selection.rst
@@ -18,9 +18,14 @@ Parameters
     * - Parameter
       - Type
       - Description
-    * - types
+    * - templateKeys
       - string
-      - If set, only snippets of the type can be selected.
+      - Comma separated list of template keys. If set, only snippets using one of these templates
+        can be selected.
+    * - groups
+      - string
+      - Comma separated list of group identifiers, available since Sulu 3.1. If set, only snippets
+        belonging to one of these groups can be selected. See :ref:`templates-template-groups`.
     * - default
       - string
       - If set, the default snippet of the given area will be used as fallback value if no snippet is selected.
@@ -59,7 +64,7 @@ Example
         </meta>
 
         <params>
-            <param name="types" value="sidebar"/>
+            <param name="templateKeys" value="sidebar"/>
             <param name="default" value="footer_social_media_links"/>
         </params>
     </property>


### PR DESCRIPTION
Adds a Template Groups section to book/templates.rst covering the <group> element (article and snippet templates only, not pages): how it splits the list into per-group tabs, the per-group security contexts, and filtering selection fields/smart content by group. Adds a short pointer with an example in bundles/snippet.rst.

Covers both the article-side feature (sulu/sulu#8124, previously undocumented) and the snippet-side feature (sulu/sulu#9065).